### PR TITLE
feat: tcpProxies, volume, domain tools, also adds database workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 build/
+.cursor/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -235,13 +235,29 @@ Here's how these layers work together:
 
 ```typescript
 import { z } from 'zod';
-import { createTool } from '@/utils/tools';
+import { createTool, formatToolDescription } from '@/utils/tools';
 import { exampleService } from '@/services/example.service';
 
 export const exampleTools = [
   createTool(
     "example-action",
-    "Description of what this tool does",
+    formatToolDescription({
+      type: 'API',
+      description: "Description of what this tool does",
+      bestFor: [
+        "Use case 1",
+        "Use case 2"
+      ],
+      notFor: [
+        "Anti-pattern 1"
+      ],
+      relations: {
+        prerequisites: ["required-tool"],
+        alternatives: ["alternative-tool"],
+        nextSteps: ["next-tool"],
+        related: ["related-tool"]
+      }
+    }),
     {
       param1: z.string().describe("Description of parameter 1"),
       param2: z.number().optional().describe("Optional parameter 2"),

--- a/README.md
+++ b/README.md
@@ -56,34 +56,69 @@ A [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server for in
 - ✅ Authentication with Railway API tokens
 - ✅ Project management (list, info, delete)
 - ✅ Deployment management (list, restart)
-- 🚧🔨⏳ Service management (create from GitHub repo or Docker image, list)
-- 🚧🔨⏳ Variable management (list, create/update, delete)
-- ❌ Service Network management
-- ❌ Volume management
+- ✅  Service management (create from GitHub repo or Docker image, list)
+- ✅  Variable management (list, create/update, delete)
+- ✅ Service Network management
+- ✅ Volume management
 - ❌ Full support for all templates
-   - ❌ Database template support
+   - 🚧🔨⏳	 Database template support
    - Automatic database and networking workflows
-- ❌ Most commonly used workflows
-- ❌ More Robust checks for deployed services
+- 🚧🔨⏳	Most commonly used workflows
+- ❌ Automatic GitHub repository linking for services
 
 ## Installation
 
-### Installing Locally
-
-#### Prerequisites
+### Prerequisites
 
 - Node.js 18+ (for built-in fetch API support)
 - An active Railway account
 - A Railway API token (create one at https://railway.app/account/tokens)
 
+
 #### Quick Start
 
 This MCP server is designed to work with MCP Clients like:
 - Claude for Desktop | ✅ Battle-Tested
+- Cursor | ✅ Needs Testing
 - Cline | 🚧🔨⏳ Needs Testing
-- Cursor | 🚧🔨⏳Needs Testing
 - Windsurf | 🚧🔨⏳ Needs Testing
 - Other MCP Clients | 🚧🔨⏳ Needs Testing
+
+### Installing via Smithery
+
+To install railway-mcp automatically, we recommend using [Smithery](https://smithery.ai/server/@jason-tan-swe/railway-mcp)
+
+**Claude Desktop**
+
+```bash
+npx -y @smithery/cli install @jason-tan-swe/railway-mcp --client claude
+```
+
+**Cursor**
+```
+npx -y @smithery/cli install @jason-tan-swe/railway-mcp --client cursor
+```
+
+
+<details>
+<summary> <h3>Manual Installation For Cursor</h3></summary>
+
+1. Head to your cursor settings and find the MCP section
+
+2. Click 'Add new MCP server'
+
+3. Name it however, you like, we recommend `railway-mcp` for better clarity
+
+4. Paste this command into the 'Command' section, where <RAILWAY_API_TOKEN> is your accounts Railway token:
+
+```bash
+npx -y @jasontanswe/railway-mcp <RAILWAY_API_TOKEN>
+```
+</details>
+
+<details>
+
+<summary><h3>Manual Installation For Claude</h3></summary>
 
 1. Create or edit your Claude for Desktop config file:
    - macOS: `~/Library/Application\ Support/Claude/claude_desktop_config.json`
@@ -133,14 +168,60 @@ Please list all my Railway projects
 ```
 Please configure the Railway API with my token: {YOUR_API_TOKEN_HERE}
 ```
+</details>
 
-### Installing via Smithery
+## Recommendations and Other Information
+This server best combines with MCP-clients that have access to terminal or with Git **(Cursor, Windsurf)**. Using this MCP with others is recommended as railway-mcp orchestrates containers and streamlines your deployment process seamlessly.
 
-To install railway-mcp for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@jason-tan-swe/railway-mcp):
+### Recommended MCP servers to combine with
+- Git || [Official Link](https://github.com/modelcontextprotocol/servers/tree/main/src/git)
+- GitHub || [Official](https://github.com/modelcontextprotocol/servers/tree/main/src/github) || [Smithery](https://smithery.ai/server/@smithery-ai/github)
 
-```bash
-npx -y @smithery/cli install @jason-tan-swe/railway-mcp --client claude
-```
+
+### For Claude
+- Out of the box, Claude does not have terminal access, so it cannot trigger deployments as it will not be able to get the latest commit.
+- Spinning up different services and monitoring them are the best use case with Claude.
+
+
+### For Cursor
+- Use with GitHub MCP or have the repository already setup on GitHub and cloned locally on your machine to leverage full integration with railway-mcp.
+- When Cursor makes a change, it may forget to push it's changes to GitHub causing it to try and deploy a commit that Railway cannot pull.
+  - **SOLUTION:** Always ask or include somewhere in your prompt: `Have you pushed our changes to GitHub yet?`
+
+## Security Considerations
+
+- Railway API tokens provide full access to your account. Keep them secure.
+- When using the environment variable method, your token is stored in the Claude Desktop configuration file.
+- Sensitive variable values are automatically masked when displayed.
+- All API calls use HTTPS for secure communication.
+- The server's memory-only token storage means your token is never written to disk outside of the configuration file.
+
+## Troubleshooting
+
+If you encounter issues:
+
+1. **Token Authentication Issues**
+   - Ensure your API token is valid and has the necessary permissions
+   - If using the environment variable method, check that the token is correctly formatted in the config file
+   - Try using the `configure` tool directly in Claude if the environment token isn't working
+
+2. **Server Connection Issues**
+   - Check that you've installed the latest version of the server
+   - Verify that Node.js version 18 or higher is installed
+   - Restart Claude for Desktop after making changes to the configuration
+
+3. **API Errors**
+   - Verify that you're using correct project, environment, and service IDs
+   - Check Railway's status page for any service disruptions
+   - Railway API has rate limits - avoid making too many requests in a short period
+
+## Contributing
+
+We welcome contributions from the community! Please see our [Contributing Guidelines](CONTRIBUTING.md) for details on how to get started, development guidelines, and debugging information.
+
+
+
+</details>
 
 ## Available Tools
 
@@ -184,7 +265,8 @@ npx -y @smithery/cli install @jason-tan-swe/railway-mcp --client claude
 - `database-deploy` - Deploy a new database service
 </details>
 
-## Example Workflows
+<details>
+<summary>Example Workflows</summary>
 
 ### Setting up a new service
 
@@ -200,33 +282,5 @@ npx -y @smithery/cli install @jason-tan-swe/railway-mcp --client claude
 3. Create or update variables as needed
 4. Delete any obsolete variables
 
-## Security Considerations
+</details>
 
-- Railway API tokens provide full access to your account. Keep them secure.
-- When using the environment variable method, your token is stored in the Claude Desktop configuration file.
-- Sensitive variable values are automatically masked when displayed.
-- All API calls use HTTPS for secure communication.
-- The server's memory-only token storage means your token is never written to disk outside of the configuration file.
-
-## Troubleshooting
-
-If you encounter issues:
-
-1. **Token Authentication Issues**
-   - Ensure your API token is valid and has the necessary permissions
-   - If using the environment variable method, check that the token is correctly formatted in the config file
-   - Try using the `configure` tool directly in Claude if the environment token isn't working
-
-2. **Server Connection Issues**
-   - Check that you've installed the latest version of the server
-   - Verify that Node.js version 18 or higher is installed
-   - Restart Claude for Desktop after making changes to the configuration
-
-3. **API Errors**
-   - Verify that you're using correct project, environment, and service IDs
-   - Check Railway's status page for any service disruptions
-   - Railway API has rate limits - avoid making too many requests in a short period
-
-## Contributing
-
-We welcome contributions from the community! Please see our [Contributing Guidelines](CONTRIBUTING.md) for details on how to get started, development guidelines, and debugging information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jasontanswe/railway-mcp",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jasontanswe/railway-mcp",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.6.0",

--- a/src/api/api-client.ts
+++ b/src/api/api-client.ts
@@ -1,22 +1,31 @@
 import { BaseApiClient } from './base-client.js';
 import { DeploymentRepository } from './repository/deployment.repo.js';
+import { DomainRepository } from './repository/domain.repo.js';
 import { ProjectRepository } from './repository/project.repo.js';
 import { ServiceRepository } from './repository/service.repo.js';
+import { TcpProxyRepository } from './repository/tcpProxy.repo.js';
 import { VariableRepository } from './repository/variable.repo.js';
+import { VolumeRepository } from './repository/volume.repo.js';
 
 export class RailwayApiClient extends BaseApiClient {
   public readonly deployments: DeploymentRepository;
+  public readonly domains: DomainRepository;
   public readonly projects: ProjectRepository;
   public readonly services: ServiceRepository;
+  public readonly tcpProxies: TcpProxyRepository;
   public readonly variables: VariableRepository;
+  public readonly volumes: VolumeRepository;
   private initialized: boolean = false;
 
   public constructor() {
     super();
     this.deployments = new DeploymentRepository(this);
+    this.domains = new DomainRepository(this);
     this.projects = new ProjectRepository(this);
     this.services = new ServiceRepository(this);
+    this.tcpProxies = new TcpProxyRepository(this);
     this.variables = new VariableRepository(this);
+    this.volumes = new VolumeRepository(this);
   }
 
   public async initialize(): Promise<void> {

--- a/src/api/repository/deployment.repo.ts
+++ b/src/api/repository/deployment.repo.ts
@@ -96,7 +96,10 @@ export class DeploymentRepository {
           timestamp
           message
           severity
-          attributes
+          attributes {
+            key
+            value
+          }
         }
       }
     `, { deploymentId, limit });

--- a/src/api/repository/domain.repo.ts
+++ b/src/api/repository/domain.repo.ts
@@ -1,0 +1,108 @@
+import { RailwayApiClient } from '@/api/api-client.js';
+import { ServiceDomain, ServiceDomainCreateInput, ServiceDomainUpdateInput, DomainAvailabilityResult, DomainsListResult } from '@/types.js';
+
+export class DomainRepository {
+  constructor(private client: RailwayApiClient) {}
+
+  async serviceDomainCreate(input: ServiceDomainCreateInput): Promise<ServiceDomain> {
+    const query = `
+      mutation serviceDomainCreate($input: ServiceDomainCreateInput!) {
+        serviceDomainCreate(input: $input) {
+          id
+          createdAt
+          deletedAt
+          domain
+          environmentId
+          projectId
+          serviceId
+          suffix
+          targetPort
+          updatedAt
+        }
+      }
+    `;
+
+    const variables = { input };
+    const response = await this.client.request<{ serviceDomainCreate: ServiceDomain }>(query, variables);
+    return response.serviceDomainCreate;
+  }
+
+  async serviceDomainDelete(id: string): Promise<boolean> {
+    const query = `
+      mutation serviceDomainDelete($id: String!) {
+        serviceDomainDelete(id: $id)
+      }
+    `;
+
+    const variables = { id };
+    const response = await this.client.request<{ serviceDomainDelete: boolean }>(query, variables);
+    return response.serviceDomainDelete;
+  }
+
+  async serviceDomainUpdate(input: ServiceDomainUpdateInput): Promise<boolean> {
+    const query = `
+      mutation serviceDomainUpdate($input: ServiceDomainUpdateInput!) {
+        serviceDomainUpdate(input: $input)
+      }
+    `;
+
+    const variables = { input };
+    const response = await this.client.request<{ serviceDomainUpdate: boolean }>(query, variables);
+    return response.serviceDomainUpdate;
+  }
+
+  async domains(projectId: string, environmentId: string, serviceId: string): Promise<DomainsListResult> {
+    const query = `
+      query domains($projectId: String!, $environmentId: String!, $serviceId: String!) {
+        domains(
+          projectId: $projectId
+          environmentId: $environmentId
+          serviceId: $serviceId
+        ) {
+          customDomains {
+            id
+            createdAt
+            deletedAt
+            domain
+            environmentId
+            projectId
+            serviceId
+            targetPort
+            updatedAt
+          }
+          serviceDomains {
+            id
+            createdAt
+            deletedAt
+            domain
+            environmentId
+            projectId
+            serviceId
+            suffix
+            targetPort
+            updatedAt
+          }
+        }
+      }
+    `;
+
+    const variables = { projectId, environmentId, serviceId };
+    const response = await this.client.request<{ domains: DomainsListResult }>(query, variables);
+    return response.domains;
+  }
+
+  async serviceDomainAvailable(domain: string): Promise<DomainAvailabilityResult> {
+    const query = `
+      query serviceDomainAvailable($domain: String!) {
+        serviceDomainAvailable(domain: $domain) {
+          available
+          message
+        }
+      }
+    `;
+
+    const variables = { domain };
+    const response = await this.client.request<{ serviceDomainAvailable: DomainAvailabilityResult }>(query, variables);
+    return response.serviceDomainAvailable;
+  }
+} 

--- a/src/api/repository/service.repo.ts
+++ b/src/api/repository/service.repo.ts
@@ -1,5 +1,5 @@
 import { RailwayApiClient } from '@/api/api-client.js';
-import { Service, ServiceInstance, ServiceCreateInput, ProjectResponse } from '@/types.js';
+import { Service, ServiceInstance, ServiceCreateInput, ProjectResponse, RegionCode } from '@/types.js';
 
 export class ServiceRepository {
   constructor(private client: RailwayApiClient) {}
@@ -102,16 +102,9 @@ export class ServiceRepository {
   async updateServiceInstance(
     serviceId: string,
     environmentId: string,
-    updates: Partial<{
-      buildCommand: string;
-      startCommand: string;
-      rootDirectory: string;
-      healthcheckPath: string;
-      numReplicas: number;
-      sleepApplication: boolean;
-    }>
-  ): Promise<void> {
-    await this.client.request<{ serviceInstanceUpdate: boolean }>(`
+    updates: Partial<ServiceInstance>
+  ): Promise<boolean> {
+    const data = await this.client.request<{ serviceInstanceUpdate: boolean }>(`
       mutation serviceInstanceUpdate(
         $serviceId: String!,
         $environmentId: String!,
@@ -120,22 +113,26 @@ export class ServiceRepository {
         $rootDirectory: String,
         $healthcheckPath: String,
         $numReplicas: Int,
-        $sleepApplication: Boolean
+        $sleepApplication: Boolean,
+        $region: String
       ) {
         serviceInstanceUpdate(
+          serviceId: $serviceId,
+          environmentId: $environmentId,
           input: {
-            serviceId: $serviceId,
-            environmentId: $environmentId,
-          },
-          buildCommand: $buildCommand,
-          startCommand: $startCommand,
-          rootDirectory: $rootDirectory,
-          healthcheckPath: $healthcheckPath,
-          numReplicas: $numReplicas,
-          sleepApplication: $sleepApplication
+            buildCommand: $buildCommand,
+            startCommand: $startCommand,
+            rootDirectory: $rootDirectory,
+            healthcheckPath: $healthcheckPath,
+            numReplicas: $numReplicas,
+            sleepApplication: $sleepApplication,
+            region: $region
+          }
         )
       }
     `, { serviceId, environmentId, ...updates });
+
+    return data.serviceInstanceUpdate;
   }
 
   async deleteService(serviceId: string): Promise<void> {

--- a/src/api/repository/service.repo.ts
+++ b/src/api/repository/service.repo.ts
@@ -13,22 +13,22 @@ export class ServiceRepository {
               node {
                 name
                 id
-            deployments(first: 5) {
-              edges {
-                node {
-                  id
-                  createdAt
-                  canRedeploy
-                  deploymentStopped
-                  environmentId
+                deployments(first: 5) {
+                  edges {
+                    node {
+                      id
+                      createdAt
+                      canRedeploy
+                      deploymentStopped
+                      environmentId
+                    }
+                  }
                 }
               }
             }
           }
         }
       }
-    }
-  }
     `, { projectId });
 
     return data.project.services.edges.map(edge => edge.node);

--- a/src/api/repository/tcpProxy.repo.ts
+++ b/src/api/repository/tcpProxy.repo.ts
@@ -1,0 +1,75 @@
+import { RailwayApiClient } from '@/api/api-client.js';
+import { TcpProxy, TcpProxyCreateInput } from '@/types.js';
+
+export class TcpProxyRepository {
+  constructor(private client: RailwayApiClient) {}
+
+  /**
+   * Create a new TCP proxy for a service in an environment
+   * @param input The creation parameters for the TCP proxy
+   */
+  async tcpProxyCreate(input: TcpProxyCreateInput): Promise<TcpProxy> {
+    const query = `
+      mutation tcpProxyCreate($input: TCPProxyCreateInput!) {
+        tcpProxyCreate(input: $input) {
+          id
+          applicationPort
+          createdAt
+          deletedAt
+          domain
+          environmentId
+          proxyPort
+          serviceId
+          updatedAt
+        }
+      }
+    `;
+
+    const variables = { input };
+    const response = await this.client.request<{ tcpProxyCreate: TcpProxy }>(query, variables);
+    return response.tcpProxyCreate;
+  }
+
+  /**
+   * Delete a TCP proxy by ID
+   * @param id The ID of the TCP proxy to delete
+   */
+  async tcpProxyDelete(id: string): Promise<boolean> {
+    const query = `
+      mutation tcpProxyDelete($id: String!) {
+        tcpProxyDelete(id: $id)
+      }
+    `;
+
+    const variables = { id };
+    const response = await this.client.request<{ tcpProxyDelete: boolean }>(query, variables);
+    return response.tcpProxyDelete;
+  }
+
+  /**
+   * List all TCP proxies for a service in an environment
+   * @param environmentId The environment ID
+   * @param serviceId The service ID
+   */
+  async listTcpProxies(environmentId: string, serviceId: string): Promise<TcpProxy[]> {
+    const query = `
+      query tcpProxies($environmentId: String!, $serviceId: String!) {
+        tcpProxies(environmentId: $environmentId, serviceId: $serviceId) {
+          id
+          applicationPort
+          createdAt
+          deletedAt
+          domain
+          environmentId
+          proxyPort
+          serviceId
+          updatedAt
+        }
+      }
+    `;
+
+    const variables = { environmentId, serviceId };
+    const response = await this.client.request<{ tcpProxies: TcpProxy[] }>(query, variables);
+    return response.tcpProxies;
+  }
+} 

--- a/src/api/repository/volume.repo.ts
+++ b/src/api/repository/volume.repo.ts
@@ -1,0 +1,77 @@
+import { RailwayApiClient } from '@/api/api-client.js';
+import { Volume, VolumeCreateInput, VolumeUpdateInput } from '@/types.js';
+
+export class VolumeRepository {
+  constructor(private client: RailwayApiClient) {}
+
+  async createVolume(input: VolumeCreateInput): Promise<Volume> {
+    const data = await this.client.request<{ volumeCreate: Volume }>(`
+      mutation volumeCreate($input: VolumeCreateInput!) {
+        volumeCreate(input: $input) {
+          createdAt
+          id
+          name
+          projectId
+        }
+      }
+    `, { input });
+
+    return data.volumeCreate;
+  }
+
+  async updateVolume(volumeId: string, input: VolumeUpdateInput): Promise<Volume> {
+    const data = await this.client.request<{ volumeUpdate: Volume }>(`
+      mutation volumeUpdate($input: VolumeUpdateInput!, $volumeId: String!) {
+        volumeUpdate(input: $input, volumeId: $volumeId) {
+          createdAt
+          id
+          name
+          projectId
+        }
+      }
+    `, { input, volumeId });
+
+    return data.volumeUpdate;
+  }
+
+  async deleteVolume(volumeId: string): Promise<boolean> {
+    const data = await this.client.request<{ volumeDelete: boolean }>(`
+      mutation volumeDelete($volumeId: String!) {
+        volumeDelete(volumeId: $volumeId)
+      }
+    `, { volumeId });
+
+    return data.volumeDelete;
+  }
+
+  async listVolumes(projectId: string): Promise<Volume[]> {
+    const data = await this.client.request<{ project: { volumes: { edges: { node: Volume }[] } } }>(`
+      query project($projectId: String!) {
+        project(id: $projectId) {
+          volumes {
+            edges {
+              node {
+                createdAt
+                id
+                name
+                projectId
+                volumeInstances(first: 5) {
+                  edges {
+                    node {
+                      createdAt
+                      id
+                      mountPath
+                      state
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    `, { projectId });
+
+    return data.project.volumes.edges.map(edge => edge.node);
+  }
+} 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,12 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { railwayClient } from "@/api/api-client.js";
 import { registerAllTools } from "@/tools/index.js";
 
+// Get token from command line if provided
+const cliToken = process.argv[2];
+if (cliToken) {
+  process.env.RAILWAY_API_TOKEN = cliToken;
+}
+
 const server = new McpServer({
   name: "railway-mcp",
   version: "1.0.0",
@@ -21,7 +27,7 @@ async function main() {
   
   const hasToken = railwayClient.getToken() !== null;
   console.error(hasToken 
-    ? "Railway MCP server running with API token from environment"
+    ? "Railway MCP server running with API token" + (cliToken ? " from command line" : " from environment")
     : "Railway MCP server running without API token - use 'configure' tool to set token"
   );
 }

--- a/src/services/deployment.service.ts
+++ b/src/services/deployment.service.ts
@@ -102,6 +102,10 @@ ${deployment.url ? `URL: ${deployment.url}` : ''}`;
 
   async healthCheckDeployment(deploymentId: string) {
     try {
+      // Wait for 5 seconds before checking status
+      // Seems like the LLMs like to call this function multiple times in combination
+      // with the health check function, so we need to wait a bit
+      await new Promise(resolve => setTimeout(resolve, 5000));
       const status = await this.client.deployments.healthCheckDeployment(deploymentId);
       const emoji = getStatusEmoji(status);
       

--- a/src/services/deployment.service.ts
+++ b/src/services/deployment.service.ts
@@ -4,17 +4,8 @@ import { createSuccessResponse, createErrorResponse, formatError } from '@/utils
 import { getStatusEmoji } from '@/utils/helpers.js';
 
 export class DeploymentService extends BaseService {
-  private static instance: DeploymentService | null = null;
-
   public constructor() {
     super();
-  }
-
-  public static getInstance(): DeploymentService {
-    if (!DeploymentService.instance) {
-      DeploymentService.instance = new DeploymentService();
-    }
-    return DeploymentService.instance;
   }
 
   async listDeployments(projectId: string, serviceId: string, environmentId: string, limit: number = 5) {
@@ -55,6 +46,11 @@ ${deployment.url ? `URL: ${deployment.url}` : ''}`;
 
   async triggerDeployment(projectId: string, serviceId: string, environmentId: string, commitSha?: string) {
     try {
+      // Wait for 5 seconds before triggering deployment
+      // Seems like the LLMs like to call this function multiple times in combination
+      // with the health check function and the list deployments function
+      // so we need to wait a bit to avoid rate limiting
+      await new Promise(resolve => setTimeout(resolve, 5000));
       const deploymentId = await this.client.deployments.triggerDeployment({
         serviceId,
         environmentId,
@@ -70,15 +66,20 @@ ${deployment.url ? `URL: ${deployment.url}` : ''}`;
     }
   }
 
-  async getDeploymentLogs(deploymentId: string, type: 'build' | 'deployment' = 'deployment', limit: number = 100) {
+  async getDeploymentLogs(deploymentId: string, limit: number = 100) {
     try {
-      const logs: DeploymentLog[] = type === 'build'
-        ? await this.client.deployments.getBuildLogs(deploymentId, limit)
-        : await this.client.deployments.getDeploymentLogs(deploymentId, limit);
+      // Wait for 5 seconds before fetching logs
+      // Seems like the LLMs like to call this function multiple times in combination
+      // with the health check function, so we need to wait a bit to avoid rate limiting
+      await new Promise(resolve => setTimeout(resolve, 5000));
+      const buildLogs = await this.client.deployments.getBuildLogs(deploymentId, limit);
+      const deploymentLogs = await this.client.deployments.getDeploymentLogs(deploymentId, limit);
+
+      const logs: DeploymentLog[] = [...buildLogs.map(log => ({ ...log, type: 'build' as const })), ...deploymentLogs.map(log => ({ ...log, type: 'deployment' as const })) ];
 
       if (logs.length === 0) {
         return createSuccessResponse({
-          text: `No ${type} logs found for deployment ${deploymentId}`,
+          text: `No logs found for deployment ${deploymentId}`,
           data: []
         });
       }
@@ -87,7 +88,7 @@ ${deployment.url ? `URL: ${deployment.url}` : ''}`;
         const timestamp = new Date(log.timestamp).toLocaleString();
         const severity = log.severity.toLowerCase();
         const emoji = severity === 'error' ? '❌' : severity === 'warn' ? '⚠️' : '📝';
-        return `[${timestamp}] ${emoji} ${log.message}`;
+        return `[${log.type}] [${timestamp}] ${emoji} ${log.message}`;
       }).join('\n');
 
       return createSuccessResponse({
@@ -95,7 +96,7 @@ ${deployment.url ? `URL: ${deployment.url}` : ''}`;
         data: logs
       });
     } catch (error) {
-      return createErrorResponse(`Error fetching ${type} logs: ${formatError(error)}`);
+      return createErrorResponse(`Error fetching logs: ${formatError(error)}`);
     }
   }
 

--- a/src/services/domain.service.ts
+++ b/src/services/domain.service.ts
@@ -1,0 +1,151 @@
+import { BaseService } from './base.service.js';
+import { ServiceDomainCreateInput, ServiceDomainUpdateInput } from '@/types.js';
+import { createSuccessResponse, createErrorResponse, formatError } from '@/utils/responses.js';
+import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+
+export class DomainService extends BaseService {
+
+  public constructor() {
+    super();
+  }
+
+  /**
+   * Create a service domain for a service in a specific environment
+   * @param input Service domain creation parameters
+   */
+  async createServiceDomain(input: ServiceDomainCreateInput): Promise<CallToolResult> {
+    try {
+      // Check domain availability if a domain is specified
+      if (input.domain) {
+        const availability = await this.client.domains.serviceDomainAvailable(input.domain);
+        if (!availability.available) {
+          return createErrorResponse(`Domain unavailable: ${availability.message}`);
+        }
+      }
+      
+      const domain = await this.client.domains.serviceDomainCreate(input);
+      return createSuccessResponse({
+        text: `Domain created successfully: ${domain.domain} (ID: ${domain.id}, Port: ${domain.targetPort || 'default'})`,
+        data: domain
+      });
+    } catch (error) {
+      return createErrorResponse(`Error creating domain: ${formatError(error)}`);
+    }
+  }
+
+  /**
+   * Delete a service domain by ID
+   * @param id Domain ID to delete
+   */
+  async deleteServiceDomain(id: string): Promise<CallToolResult> {
+    try {
+      const result = await this.client.domains.serviceDomainDelete(id);
+      
+      if (result) {
+        return createSuccessResponse({
+          text: `Domain with ID ${id} deleted successfully`,
+          data: { success: true }
+        });
+      } else {
+        return createErrorResponse(`Failed to delete domain with ID ${id}`);
+      }
+    } catch (error) {
+      return createErrorResponse(`Error deleting domain: ${formatError(error)}`);
+    }
+  }
+
+  /**
+   * Update a service domain's target port
+   * @param input Update parameters including domain ID and new target port
+   */
+  async updateServiceDomain(input: ServiceDomainUpdateInput): Promise<CallToolResult> {
+    try {
+      const result = await this.client.domains.serviceDomainUpdate(input);
+      
+      if (result) {
+        return createSuccessResponse({
+          text: `Domain with ID ${input.id} updated successfully with new target port: ${input.targetPort}`,
+          data: { success: true }
+        });
+      } else {
+        return createErrorResponse(`Failed to update domain with ID ${input.id}`);
+      }
+    } catch (error) {
+      return createErrorResponse(`Error updating domain: ${formatError(error)}`);
+    }
+  }
+
+  /**
+   * List all domains (both service and custom) for a service in a specific environment
+   * @param projectId Railway project ID
+   * @param environmentId Railway environment ID
+   * @param serviceId Railway service ID
+   */
+  async listDomains(
+    projectId: string, 
+    environmentId: string, 
+    serviceId: string
+  ): Promise<CallToolResult> {
+    try {
+      const domains = await this.client.domains.domains(projectId, environmentId, serviceId);
+      
+      // Format the domains text output
+      let domainsText = '';
+      
+      if (domains.serviceDomains.length === 0 && domains.customDomains.length === 0) {
+        domainsText = 'No domains found for this service.';
+      } else {
+        if (domains.serviceDomains.length > 0) {
+          domainsText += 'Service Domains:\n';
+          domains.serviceDomains.forEach(domain => {
+            domainsText += `- ${domain.domain} (ID: ${domain.id}, Port: ${domain.targetPort || 'default'})\n`;
+          });
+        } else {
+          domainsText += 'No service domains found.\n';
+        }
+        
+        domainsText += '\nCustom Domains:\n';
+        if (domains.customDomains.length > 0) {
+          domains.customDomains.forEach(domain => {
+            domainsText += `- ${domain.domain} (ID: ${domain.id}, Port: ${domain.targetPort || 'default'})\n`;
+          });
+        } else {
+          domainsText += 'No custom domains found.\n';
+        }
+      }
+      
+      return createSuccessResponse({
+        text: domainsText,
+        data: domains
+      });
+    } catch (error) {
+      return createErrorResponse(`Error listing domains: ${formatError(error)}`);
+    }
+  }
+
+  /**
+   * Check if a service domain is available
+   * @param domain Domain to check
+   */
+  async checkDomainAvailability(domain: string): Promise<CallToolResult> {
+    try {
+      const result = await this.client.domains.serviceDomainAvailable(domain);
+      
+      if (result.available) {
+        return createSuccessResponse({
+          text: `Domain ${domain} is available`,
+          data: result
+        });
+      } else {
+        return createSuccessResponse({
+          text: `Domain ${domain} is not available: ${result.message}`,
+          data: result
+        });
+      }
+    } catch (error) {
+      return createErrorResponse(`Error checking domain availability: ${formatError(error)}`);
+    }
+  }
+}
+
+export const domainService = new DomainService(); 

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,5 +1,8 @@
 export { databaseService } from './database.service.js';
 export { deploymentService } from './deployment.service.js';
+export { domainService } from './domain.service.js';
 export { projectService } from './project.service.js';
 export { serviceService } from './service.service.js';
-export { variableService } from './variable.service.js'; 
+export { tcpProxyService } from './tcpProxy.service.js';
+export { variableService } from './variable.service.js';
+export { volumeService } from './volume.service.js'; 

--- a/src/services/project.service.ts
+++ b/src/services/project.service.ts
@@ -3,17 +3,9 @@ import { createSuccessResponse, createErrorResponse, formatError } from '@/utils
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 
 export class ProjectService extends BaseService {
-  private static instance: ProjectService | null = null;
 
   public constructor() {
     super();
-  }
-
-  public static getInstance(): ProjectService {
-    if (!ProjectService.instance) {
-      ProjectService.instance = new ProjectService();
-    }
-    return ProjectService.instance;
   }
 
   async listProjects() {

--- a/src/services/service.service.ts
+++ b/src/services/service.service.ts
@@ -125,7 +125,11 @@ Sleep Mode: ${serviceInstance.sleepApplication ? 'Enabled' : 'Disabled'}${deploy
 
   async updateService(projectId: string, serviceId: string, environmentId: string, config: Partial<ServiceInstance>) {
     try {
-      await this.client.services.updateServiceInstance(serviceId, environmentId, config);
+      const updated = await this.client.services.updateServiceInstance(serviceId, environmentId, config);
+      if (!updated) {
+        return createErrorResponse(`Error updating service: Failed to update service instance of ${serviceId} in environment ${environmentId}`);
+      }
+
       return createSuccessResponse({
         text: `Service configuration updated successfully`
       });
@@ -148,6 +152,7 @@ Sleep Mode: ${serviceInstance.sleepApplication ? 'Enabled' : 'Disabled'}${deploy
   async restartService(serviceId: string, environmentId: string) {
     try {
       await this.client.services.restartService(serviceId, environmentId);
+      await new Promise(resolve => setTimeout(resolve, 5000)); // TEMPORARY UNTIL WEBHOOKS ARE IMPLEMENTED: Wait for 5 seconds to ensure the service is restarted
       return createSuccessResponse({
         text: `Service restarted successfully`
       });

--- a/src/services/service.service.ts
+++ b/src/services/service.service.ts
@@ -3,17 +3,9 @@ import { Service, ServiceInstance } from '@/types.js';
 import { createSuccessResponse, createErrorResponse, formatError } from '@/utils/responses.js';
 
 export class ServiceService extends BaseService {
-  private static instance: ServiceService | null = null;
 
   public constructor() {
     super();
-  }
-
-  public static getInstance(): ServiceService {
-    if (!ServiceService.instance) {
-      ServiceService.instance = new ServiceService();
-    }
-    return ServiceService.instance;
   }
 
   async listServices(projectId: string) {

--- a/src/services/tcpProxy.service.ts
+++ b/src/services/tcpProxy.service.ts
@@ -1,0 +1,84 @@
+import { BaseService } from './base.service.js';
+import { TcpProxyCreateInput } from '@/types.js';
+import { createSuccessResponse, createErrorResponse, formatError } from '@/utils/responses.js';
+import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+
+export class TcpProxyService extends BaseService {
+  public constructor() {
+    super();
+  }
+
+  /**
+   * Create a new TCP proxy for a service in a specific environment
+   * @param input TCP proxy creation parameters
+   */
+  async createTcpProxy(input: TcpProxyCreateInput): Promise<CallToolResult> {
+    try {
+      const tcpProxy = await this.client.tcpProxies.tcpProxyCreate(input);
+      return createSuccessResponse({
+        text: `TCP Proxy created successfully:
+- Application Port: ${tcpProxy.applicationPort}
+- Proxy Port: ${tcpProxy.proxyPort}
+- Domain: ${tcpProxy.domain}
+- ID: ${tcpProxy.id}`,
+        data: tcpProxy
+      });
+    } catch (error) {
+      return createErrorResponse(`Error creating TCP proxy: ${formatError(error)}`);
+    }
+  }
+
+  /**
+   * Delete a TCP proxy by ID
+   * @param id TCP proxy ID to delete
+   */
+  async deleteTcpProxy(id: string): Promise<CallToolResult> {
+    try {
+      const result = await this.client.tcpProxies.tcpProxyDelete(id);
+      
+      if (result) {
+        return createSuccessResponse({
+          text: `TCP Proxy with ID ${id} deleted successfully`,
+          data: { success: true }
+        });
+      } else {
+        return createErrorResponse(`Failed to delete TCP Proxy with ID ${id}`);
+      }
+    } catch (error) {
+      return createErrorResponse(`Error deleting TCP proxy: ${formatError(error)}`);
+    }
+  }
+
+  /**
+   * List all TCP proxies for a service in a specific environment
+   * @param environmentId Railway environment ID
+   * @param serviceId Railway service ID
+   */
+  async listTcpProxies(environmentId: string, serviceId: string): Promise<CallToolResult> {
+    try {
+      const proxies = await this.client.tcpProxies.listTcpProxies(environmentId, serviceId);
+      
+      if (proxies.length === 0) {
+        return createSuccessResponse({
+          text: 'No TCP proxies found for this service.',
+          data: []
+        });
+      }
+      
+      const proxyDetails = proxies.map(proxy => 
+        `- Application Port: ${proxy.applicationPort} → Proxy Port: ${proxy.proxyPort}
+  Domain: ${proxy.domain}
+  ID: ${proxy.id}`
+      ).join('\n\n');
+      
+      return createSuccessResponse({
+        text: `TCP Proxies for this service:\n\n${proxyDetails}`,
+        data: proxies
+      });
+    } catch (error) {
+      return createErrorResponse(`Error listing TCP proxies: ${formatError(error)}`);
+    }
+  }
+}
+
+export const tcpProxyService = new TcpProxyService(); 

--- a/src/services/variable.service.ts
+++ b/src/services/variable.service.ts
@@ -2,17 +2,9 @@ import { BaseService } from '@/services/base.service.js';
 import { createSuccessResponse, createErrorResponse, formatError } from '@/utils/responses.js';
 
 export class VariableService extends BaseService {
-  private static instance: VariableService | null = null;
 
   public constructor() {
     super();
-  }
-
-  public static getInstance(): VariableService {
-    if (!VariableService.instance) {
-      VariableService.instance = new VariableService();
-    }
-    return VariableService.instance;
   }
 
   async listVariables(projectId: string, environmentId: string, serviceId?: string) {

--- a/src/services/volume.service.ts
+++ b/src/services/volume.service.ts
@@ -1,0 +1,113 @@
+import { BaseService } from './base.service.js';
+import { createSuccessResponse, createErrorResponse, formatError } from '@/utils/responses.js';
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+
+class VolumeService extends BaseService {
+  constructor() {
+    super();
+  }
+
+  /**
+   * List all volumes in a project
+   * 
+   * @param projectId ID of the project
+   * @returns CallToolResult with formatted response
+   */
+  async listVolumes(projectId: string): Promise<CallToolResult> {
+    try {
+      const volumes = await this.client.volumes.listVolumes(projectId);
+
+      if (volumes.length === 0) {
+        return createSuccessResponse({
+          text: "No volumes found in this project.",
+          data: []
+        });
+      }
+
+      const volumeDetails = volumes.map(volume => 
+        `📦 ${volume.name} (ID: ${volume.id})
+Created: ${new Date(volume.createdAt).toLocaleString()}`
+      );
+
+      return createSuccessResponse({
+        text: `Volumes in project:\n\n${volumeDetails.join('\n\n')}`,
+        data: volumes
+      });
+    } catch (error) {
+      return createErrorResponse(`Error listing volumes: ${formatError(error)}`);
+    }
+  }
+
+  /**
+   * Create a new volume in a project
+   * 
+   * @param projectId ID of the project where the volume will be created
+   * @param serviceId ID of the service to attach the volume to
+   * @param environmentId ID of the environment to create the volume in
+   * @param mountPath Path to mount the volume on
+   * @returns CallToolResult with formatted response
+   */
+  async createVolume(projectId: string, serviceId: string, environmentId: string, mountPath: string): Promise<CallToolResult> {
+    try {
+      const input = { projectId, serviceId, environmentId, mountPath };
+
+      // TODO: Check that the service is NOT running on Metal
+      // Apparently it gives this weird bug where volume
+      // cannot mount on service if service is running on Metal
+      const volume = await this.client.volumes.createVolume(input);
+      
+      return createSuccessResponse({
+        text: `✅ Volume "${volume.name}" created successfully (ID: ${volume.id})`,
+        data: volume
+      });
+    } catch (error) {
+      return createErrorResponse(`Error creating volume: ${formatError(error)}`);
+    }
+  }
+
+  /**
+   * Update a volume
+   * 
+   * @param volumeId ID of the volume to update
+   * @param name New name for the volume
+   * @returns CallToolResult with formatted response
+   */
+  async updateVolume(volumeId: string, name: string): Promise<CallToolResult> {
+    try {
+      const input = { name };
+      const volume = await this.client.volumes.updateVolume(volumeId, input);
+      
+      return createSuccessResponse({
+        text: `✅ Volume updated successfully to "${volume.name}" (ID: ${volume.id})`,
+        data: volume
+      });
+    } catch (error) {
+      return createErrorResponse(`Error updating volume: ${formatError(error)}`);
+    }
+  }
+
+  /**
+   * Delete a volume
+   * 
+   * @param volumeId ID of the volume to delete
+   * @returns CallToolResult with formatted response
+   */
+  async deleteVolume(volumeId: string): Promise<CallToolResult> {
+    try {
+      const success = await this.client.volumes.deleteVolume(volumeId);
+      
+      if (success) {
+        return createSuccessResponse({
+          text: "✅ Volume deleted successfully",
+          data: { success }
+        });
+      } else {
+        return createErrorResponse("Failed to delete volume");
+      }
+    } catch (error) {
+      return createErrorResponse(`Error deleting volume: ${formatError(error)}`);
+    }
+  }
+}
+
+export const volumeService = new VolumeService(); 

--- a/src/services/volume.service.ts
+++ b/src/services/volume.service.ts
@@ -1,7 +1,7 @@
 import { BaseService } from './base.service.js';
 import { createSuccessResponse, createErrorResponse, formatError } from '@/utils/responses.js';
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
-
+import { RegionCode } from '@/types.js';
 class VolumeService extends BaseService {
   constructor() {
     super();
@@ -51,10 +51,10 @@ Created: ${new Date(volume.createdAt).toLocaleString()}`
     try {
       const input = { projectId, serviceId, environmentId, mountPath };
 
-      // TODO: Check that the service is NOT running on Metal
-      // Apparently it gives this weird bug where volume
-      // cannot mount on service if service is running on Metal
       const volume = await this.client.volumes.createVolume(input);
+      if (!volume) {
+        return createErrorResponse(`Error creating volume: Failed to create volume for ${serviceId} in environment ${environmentId}`);
+      }
       
       return createSuccessResponse({
         text: `✅ Volume "${volume.name}" created successfully (ID: ${volume.id})`,

--- a/src/tools/config.tool.ts
+++ b/src/tools/config.tool.ts
@@ -1,36 +1,53 @@
 import { z } from 'zod';
-import { createTool } from '@/utils/tools.js';
+import { createTool, formatToolDescription } from '@/utils/tools.js';
 import { railwayClient } from '@/api/api-client.js';
 
 export const configTools = [
   createTool(
-    "configure",
-  "Configure the Railway API connection (only needed if not set in environment variables)",
-  {
-    token: z.string().describe("Railway API token"),
-  },
-  async ({ token }) => {
-    try {
-      await railwayClient.setToken(token);      
-      return {
-        content: [
-          {
-            type: "text" as const,
-            text: `✅ Successfully connected to Railway API`,
-          },
-        ],
-      };
-    } catch (error) {
-      return {
-        isError: true,
-        content: [
-          {
-            type: "text" as const,
-            text: `❌ Failed to connect to Railway API: ${error instanceof Error ? error.message : 'Unknown error'}`,
-          },
-        ],
-      };
+    "configure_api_token",
+    formatToolDescription({
+      type: 'UTILITY',
+      description: "Configure the Railway API token for authentication (only needed if not set in environment variables)",
+      bestFor: [
+        "Initial setup",
+        "Token updates",
+        "Authentication configuration"
+      ],
+      notFor: [
+        "Project configuration",
+        "Service settings",
+        "Environment variables"
+      ],
+      relations: {
+        nextSteps: ["project_list", "service_list"],
+        related: ["project_create"]
+      }
+    }),
+    {
+      token: z.string().describe("Railway API token (create one at https://railway.app/account/tokens)")
+    },
+    async ({ token }) => {
+      try {
+        await railwayClient.setToken(token);      
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `✅ Successfully connected to Railway API`,
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: `❌ Failed to connect to Railway API: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            },
+          ],
+        };
+      }
     }
-  }
   )
 ];

--- a/src/tools/database.tool.ts
+++ b/src/tools/database.tool.ts
@@ -5,7 +5,7 @@ import { DatabaseType } from '@/types.js';
 
 export const databaseTools = [
   createTool(
-    "database-list-types",
+    "database_list_types",
     "List all available database types that can be deployed",
     {},
     async () => {
@@ -14,15 +14,16 @@ export const databaseTools = [
   ),
 
   createTool(
-    "database-deploy",
+    "database_deploy",
     "Deploy a database service",
     {
       projectId: z.string().describe("ID of the project to deploy the database in"),
       type: z.nativeEnum(DatabaseType).describe("Type of database to deploy"),
+      environmentId: z.string().describe("ID of the environment to deploy the database in"),
       name: z.string().optional().describe("Custom name for the database service (optional)")
     },
-    async ({ projectId, type, name }) => {
-      return databaseService.createDatabase(projectId, type, name);
+    async ({ projectId, type, environmentId, name }) => {
+      return databaseService.createDatabase(projectId, type, environmentId, name);
     }
   )
 ]; 

--- a/src/tools/database.tool.ts
+++ b/src/tools/database.tool.ts
@@ -1,12 +1,30 @@
+// src/tools/database.tool.ts
+import { createTool, formatToolDescription } from '@/utils/tools.js';
 import { z } from 'zod';
-import { createTool } from '@/utils/tools.js';
 import { databaseService } from '@/services/database.service.js';
-import { DatabaseType } from '@/types.js';
+import { DatabaseType, RegionCodeSchema } from '@/types.js';
 
 export const databaseTools = [
   createTool(
     "database_list_types",
-    "List all available database types that can be deployed",
+    formatToolDescription({
+      type: 'QUERY',
+      description: "List all available database types that can be deployed using Railway's official templates",
+      bestFor: [
+        "Discovering supported database types",
+        "Planning database deployments",
+        "Checking template availability"
+      ],
+      notFor: [
+        "Listing existing databases",
+        "Getting database connection details"
+      ],
+      relations: {
+        nextSteps: ["database_deploy"],
+        alternatives: ["service_create_from_image"],
+        related: ["database_deploy", "service_create_from_image"]
+      }
+    }),
     {},
     async () => {
       return databaseService.listDatabaseTypes();
@@ -14,16 +32,46 @@ export const databaseTools = [
   ),
 
   createTool(
-    "database_deploy",
-    "Deploy a database service",
+    "database_deploy_from_template",
+    formatToolDescription({
+      type: 'WORKFLOW',
+      description: "Deploy a pre-configured database using Railway's official templates and best practices",
+      bestFor: [
+        "Standard database deployments",
+        "Quick setup with security defaults",
+        "Common database types (PostgreSQL, MongoDB, Redis)"
+      ],
+      notFor: [
+        "Custom database versions",
+        "Complex configurations",
+        "Unsupported database types"
+      ],
+      relations: {
+        prerequisites: ["database_list_types"],
+        alternatives: ["service_create_from_image"],
+        nextSteps: ["variable_list", "service_info"],
+        related: ["volume_create", "service_update"]
+      }
+    }),
     {
-      projectId: z.string().describe("ID of the project to deploy the database in"),
-      type: z.nativeEnum(DatabaseType).describe("Type of database to deploy"),
-      environmentId: z.string().describe("ID of the environment to deploy the database in"),
-      name: z.string().optional().describe("Custom name for the database service (optional)")
+      projectId: z.string().describe(
+        "ID of the project where the database will be deployed"
+      ),
+      type: z.nativeEnum(DatabaseType).describe(
+        "Type of database to deploy (e.g., postgresql, mongodb, redis). Use service_create_from_image for other types."
+      ),
+      region: RegionCodeSchema.describe(
+        "Region where the database should be deployed"
+      ),
+      environmentId: z.string().describe(
+        "Environment ID where the database will be deployed (usually obtained from project_info)"
+      ),
+      name: z.string().optional().describe(
+        "Optional custom name for the database service. Default: {type}-database"
+      )
     },
-    async ({ projectId, type, environmentId, name }) => {
-      return databaseService.createDatabase(projectId, type, environmentId, name);
+    async ({ projectId, type, environmentId, region, name }) => {
+      return databaseService.createDatabaseFromTemplate(projectId, type, region, environmentId, name);
     }
   )
-]; 
+];

--- a/src/tools/deployment.tool.ts
+++ b/src/tools/deployment.tool.ts
@@ -4,7 +4,7 @@ import { deploymentService } from '@/services/deployment.service.js';
 
 export const deploymentTools = [
   createTool(
-    "deployment-list",
+    "deployment_list",
     "List recent deployments for a service in a specific environment",
     {
       projectId: z.string().describe("ID of the project"),
@@ -18,13 +18,13 @@ export const deploymentTools = [
   ),
 
   createTool(
-    "deployment-trigger",
+    "deployment_trigger",
     "Trigger a new deployment for a service",
     {
       projectId: z.string().describe("ID of the project"),
       serviceId: z.string().describe("ID of the service"),
       environmentId: z.string().describe("ID of the environment"),
-      commitSha: z.string().optional().describe("Specific commit SHA to deploy")
+      commitSha: z.string().describe("Specific commit SHA to deploy")
     },
     async ({ projectId, serviceId, environmentId, commitSha }) => {
       return deploymentService.triggerDeployment(projectId, serviceId, environmentId, commitSha);
@@ -32,20 +32,19 @@ export const deploymentTools = [
   ),
 
   createTool(
-    "deployment-logs",
+    "deployment_logs",
     "Get logs for a specific deployment",
     {
       deploymentId: z.string().describe("ID of the deployment"),
-      type: z.enum(['build', 'deployment']).optional().describe("Type of logs to fetch"),
       limit: z.number().optional().describe("Maximum number of log entries to fetch")
     },
-    async ({ deploymentId, type = 'deployment', limit = 100 }) => {
-      return deploymentService.getDeploymentLogs(deploymentId, type, limit);
+    async ({ deploymentId, limit = 100 }) => {
+      return deploymentService.getDeploymentLogs(deploymentId, limit);
     }
   ),
 
   createTool(
-    "deployment-health-check",
+    "deployment_health_check",
     "Check the health/status of a deployment",
     {
       deploymentId: z.string().describe("ID of the deployment to check")

--- a/src/tools/deployment.tool.ts
+++ b/src/tools/deployment.tool.ts
@@ -1,30 +1,61 @@
+import { createTool, formatToolDescription } from '@/utils/tools.js';
 import { z } from 'zod';
-import { createTool } from '@/utils/tools.js';
 import { deploymentService } from '@/services/deployment.service.js';
 
 export const deploymentTools = [
   createTool(
     "deployment_list",
-    "List recent deployments for a service in a specific environment",
+    formatToolDescription({
+      type: 'API',
+      description: "List recent deployments for a service in a specific environment",
+      bestFor: [
+        "Viewing deployment history",
+        "Monitoring service updates"
+      ],
+      relations: {
+        prerequisites: ["service_list"],
+        nextSteps: ["deployment_logs", "deployment_trigger"],
+        related: ["service_info", "service_restart"]
+      }
+    }),
     {
-      projectId: z.string().describe("ID of the project"),
-      environmentId: z.string().describe("ID of the environment"),
-      serviceId: z.string().describe("ID of the service"),
-      limit: z.number().optional().describe("Maximum number of deployments to list")
+      projectId: z.string().describe("ID of the project containing the service"),
+      serviceId: z.string().describe("ID of the service to list deployments for"),
+      environmentId: z.string().describe("ID of the environment to list deployments from (usually obtained from service_list)"),
+      limit: z.number().optional().describe("Optional: Maximum number of deployments to return (default: 10)")
     },
-    async ({ projectId, environmentId, serviceId, limit = 5 }) => {
+    async ({ projectId, serviceId, environmentId, limit = 10 }) => {
       return deploymentService.listDeployments(projectId, serviceId, environmentId, limit);
     }
   ),
 
   createTool(
     "deployment_trigger",
-    "Trigger a new deployment for a service",
+    formatToolDescription({
+      type: 'API',
+      description: "Trigger a new deployment for a service",
+      bestFor: [
+        "Deploying code changes",
+        "Applying configuration updates",
+        "Rolling back to previous states"
+      ],
+      notFor: [
+        "Restarting services (use service_restart)",
+        "Updating service config (use service_update)",
+        "Database changes"
+      ],
+      relations: {
+        prerequisites: ["service_list"],
+        nextSteps: ["deployment_logs", "deployment_status"],
+        alternatives: ["service_restart"],
+        related: ["variable_set", "service_update"]
+      }
+    }),
     {
       projectId: z.string().describe("ID of the project"),
       serviceId: z.string().describe("ID of the service"),
       environmentId: z.string().describe("ID of the environment"),
-      commitSha: z.string().describe("Specific commit SHA to deploy")
+      commitSha: z.string().describe("Specific commit SHA from the Git repository")
     },
     async ({ projectId, serviceId, environmentId, commitSha }) => {
       return deploymentService.triggerDeployment(projectId, serviceId, environmentId, commitSha);
@@ -33,9 +64,26 @@ export const deploymentTools = [
 
   createTool(
     "deployment_logs",
-    "Get logs for a specific deployment",
+    formatToolDescription({
+      type: 'API',
+      description: "Get logs for a specific deployment",
+      bestFor: [
+        "Debugging deployment issues",
+        "Monitoring deployment progress",
+        "Checking build output"
+      ],
+      notFor: [
+        "Service runtime logs",
+        "Database logs"
+      ],
+      relations: {
+        prerequisites: ["deployment_list"],
+        nextSteps: ["deployment_status"],
+        related: ["service_info", "deployment_trigger"]
+      }
+    }),
     {
-      deploymentId: z.string().describe("ID of the deployment"),
+      deploymentId: z.string().describe("ID of the deployment to get logs for"),
       limit: z.number().optional().describe("Maximum number of log entries to fetch")
     },
     async ({ deploymentId, limit = 100 }) => {
@@ -44,10 +92,27 @@ export const deploymentTools = [
   ),
 
   createTool(
-    "deployment_health_check",
-    "Check the health/status of a deployment",
+    "deployment_status",
+    formatToolDescription({
+      type: 'API',
+      description: "Check the current status of a deployment",
+      bestFor: [
+        "Monitoring deployment progress",
+        "Verifying successful deployments",
+        "Checking for deployment failures"
+      ],
+      notFor: [
+        "Service runtime logs",
+        "Database logs"
+      ],
+      relations: {
+        prerequisites: ["deployment_list", "deployment_trigger"],
+        nextSteps: ["deployment_logs"],
+        related: ["service_info", "service_restart", "deployment_wait"]
+      }
+    }),
     {
-      deploymentId: z.string().describe("ID of the deployment to check")
+      deploymentId: z.string().describe("ID of the deployment to check status for")
     },
     async ({ deploymentId }) => {
       return deploymentService.healthCheckDeployment(deploymentId);

--- a/src/tools/domain.tool.ts
+++ b/src/tools/domain.tool.ts
@@ -1,15 +1,28 @@
+import { createTool, formatToolDescription } from '@/utils/tools.js';
 import { z } from 'zod';
-import { createTool } from '@/utils/tools.js';
 import { domainService } from '@/services/domain.service.js';
 
 export const domainTools = [
   createTool(
     "domain_list",
-    "List all domains for a service in a specific environment",
+    formatToolDescription({
+      type: 'API',
+      description: "List all domains (both service and custom) for a service",
+      bestFor: [
+        "Viewing service endpoints",
+        "Managing domain configurations",
+        "Auditing domain settings"
+      ],
+      relations: {
+        prerequisites: ["service_list"],
+        nextSteps: ["domain_create", "domain_update"],
+        related: ["service_info", "tcp_proxy_list"]
+      }
+    }),
     {
-      projectId: z.string().describe("ID of the project"),
-      environmentId: z.string().describe("ID of the environment"),
-      serviceId: z.string().describe("ID of the service")
+      projectId: z.string().describe("ID of the project containing the service"),
+      environmentId: z.string().describe("ID of the environment that the service is in to list domains from (usually obtained from service_list)"),
+      serviceId: z.string().describe("ID of the service to list domains for")
     },
     async ({ projectId, environmentId, serviceId }) => {
       return domainService.listDomains(projectId, environmentId, serviceId);
@@ -18,7 +31,25 @@ export const domainTools = [
 
   createTool(
     "domain_create",
-    "Create a new service domain",
+    formatToolDescription({
+      type: 'API',
+      description: "Create a new domain for a service",
+      bestFor: [
+        "Setting up custom domains",
+        "Configuring service endpoints",
+        "Adding HTTPS endpoints"
+      ],
+      notFor: [
+        "TCP proxy setup (use tcp_proxy_create)",
+        "Internal service communication"
+      ],
+      relations: {
+        prerequisites: ["service_list", "domain_check"],
+        nextSteps: ["domain_update"],
+        alternatives: ["tcp_proxy_create"],
+        related: ["service_info", "domain_list"]
+      }
+    }),
     {
       environmentId: z.string().describe("ID of the environment"),
       serviceId: z.string().describe("ID of the service"),
@@ -27,54 +58,93 @@ export const domainTools = [
       targetPort: z.number().optional().describe("Target port for the domain (optional, as railway will use the default port for the service and detect it automatically.)"),
     },
     async ({ environmentId, serviceId, domain, suffix, targetPort }) => {
-      const input = {
+      return domainService.createServiceDomain({
         environmentId,
         serviceId,
         domain,
         suffix,
         targetPort
-      };
-
-      return domainService.createServiceDomain(input);
-    }
-  ),
-
-  createTool(
-    "domain_delete",
-    "Delete a service domain",
-    {
-      id: z.string().describe("ID of the domain to delete")
-    },
-    async ({ id }) => {
-      return domainService.deleteServiceDomain(id);
-    }
-  ),
-
-  createTool(
-    "domain_update",
-    "Update a service domain target port",
-    {
-      id: z.string().describe("ID of the domain to update"),
-      targetPort: z.number().describe("New target port for the domain")
-    },
-    async ({ id, targetPort }) => {
-      const input = {
-        id,
-        targetPort
-      };
-
-      return domainService.updateServiceDomain(input);
+      });
     }
   ),
 
   createTool(
     "domain_check",
-    "Check if a service domain is available",
+    formatToolDescription({
+      type: 'API',
+      description: "Check if a domain is available for use",
+      bestFor: [
+        "Validating domain availability",
+        "Pre-deployment checks",
+        "Domain planning"
+      ],
+      relations: {
+        nextSteps: ["domain_create"],
+        related: ["domain_list"]
+      }
+    }),
     {
-      domain: z.string().describe("Domain to check availability")
+      domain: z.string().describe("Domain name to check availability for")
     },
     async ({ domain }) => {
       return domainService.checkDomainAvailability(domain);
+    }
+  ),
+
+  createTool(
+    "domain_update",
+    formatToolDescription({
+      type: 'API',
+      description: "Update a domain's configuration",
+      bestFor: [
+        "Changing target ports",
+        "Updating domain settings",
+        "Reconfiguring endpoints"
+      ],
+      notFor: [
+        "Changing domain names (delete and recreate instead)",
+        "TCP proxy configuration"
+      ],
+      relations: {
+        prerequisites: ["domain_list"],
+        nextSteps: ["domain_list"],
+        related: ["service_update"]
+      }
+    }),
+    {
+      id: z.string().describe("ID of the domain to update"),
+      targetPort: z.number().describe("New port number to route traffic to")
+    },
+    async ({ id, targetPort }) => {
+      return domainService.updateServiceDomain({ id, targetPort });
+    }
+  ),
+
+  createTool(
+    "domain_delete",
+    formatToolDescription({
+      type: 'API',
+      description: "Delete a domain from a service",
+      bestFor: [
+        "Removing unused domains",
+        "Cleaning up configurations",
+        "Domain management"
+      ],
+      notFor: [
+        "Temporary domain disabling",
+        "Port updates (use domain_update)"
+      ],
+      relations: {
+        prerequisites: ["domain_list"],
+        alternatives: ["domain_update"],
+        related: ["service_update"]
+      }
+    }),
+    {
+      id: z.string().describe("ID of the domain to delete")
+    },
+    async ({ id }) => {
+      return domainService.deleteServiceDomain(id);
     }
   )
 ]; 

--- a/src/tools/domain.tool.ts
+++ b/src/tools/domain.tool.ts
@@ -1,0 +1,80 @@
+import { z } from 'zod';
+import { createTool } from '@/utils/tools.js';
+import { domainService } from '@/services/domain.service.js';
+
+export const domainTools = [
+  createTool(
+    "domain_list",
+    "List all domains for a service in a specific environment",
+    {
+      projectId: z.string().describe("ID of the project"),
+      environmentId: z.string().describe("ID of the environment"),
+      serviceId: z.string().describe("ID of the service")
+    },
+    async ({ projectId, environmentId, serviceId }) => {
+      return domainService.listDomains(projectId, environmentId, serviceId);
+    }
+  ),
+
+  createTool(
+    "domain_create",
+    "Create a new service domain",
+    {
+      environmentId: z.string().describe("ID of the environment"),
+      serviceId: z.string().describe("ID of the service"),
+      domain: z.string().optional().describe("Custom domain name (optional, as railway will generate one for you and is generally better to leave it up to railway to generate one. There's usually no need to specify this and there are no use cases for overriding it.)"),
+      suffix: z.string().optional().describe("Suffix for the domain (optional, railway will generate one for you and is generally better to leave it up to railway to generate one.)"),
+      targetPort: z.number().optional().describe("Target port for the domain (optional, as railway will use the default port for the service and detect it automatically.)"),
+    },
+    async ({ environmentId, serviceId, domain, suffix, targetPort }) => {
+      const input = {
+        environmentId,
+        serviceId,
+        domain,
+        suffix,
+        targetPort
+      };
+
+      return domainService.createServiceDomain(input);
+    }
+  ),
+
+  createTool(
+    "domain_delete",
+    "Delete a service domain",
+    {
+      id: z.string().describe("ID of the domain to delete")
+    },
+    async ({ id }) => {
+      return domainService.deleteServiceDomain(id);
+    }
+  ),
+
+  createTool(
+    "domain_update",
+    "Update a service domain target port",
+    {
+      id: z.string().describe("ID of the domain to update"),
+      targetPort: z.number().describe("New target port for the domain")
+    },
+    async ({ id, targetPort }) => {
+      const input = {
+        id,
+        targetPort
+      };
+
+      return domainService.updateServiceDomain(input);
+    }
+  ),
+
+  createTool(
+    "domain_check",
+    "Check if a service domain is available",
+    {
+      domain: z.string().describe("Domain to check availability")
+    },
+    async ({ domain }) => {
+      return domainService.checkDomainAvailability(domain);
+    }
+  )
+]; 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -2,10 +2,13 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import { databaseTools } from './database.tool.js';
 import { deploymentTools } from './deployment.tool.js';
+import { domainTools } from './domain.tool.js';
 import { projectTools } from './project.tool.js';
 import { serviceTools } from './service.tool.js';
+import { tcpProxyTools } from './tcpProxy.tool.js';
 import { variableTools } from './variable.tool.js';
 import { configTools } from './config.tool.js';
+import { volumeTools } from './volume.tool.js';
 
 import { Tool } from '@/utils/tools.js';
 
@@ -14,10 +17,13 @@ export function registerAllTools(server: McpServer) {
   const allTools = [
     ...databaseTools,
     ...deploymentTools,
+    ...domainTools,
     ...projectTools,
     ...serviceTools,
+    ...tcpProxyTools,
     ...variableTools,
     ...configTools,
+    ...volumeTools,
   ] as Tool[];
 
   // Register each tool with the server

--- a/src/tools/project.tool.ts
+++ b/src/tools/project.tool.ts
@@ -4,7 +4,7 @@ import { projectService } from '@/services/project.service.js';
 
 export const projectTools = [
   createTool(
-    "project-list",
+    "project_list",
     "List all projects",
     {},
     async () => {
@@ -13,7 +13,7 @@ export const projectTools = [
   ),
 
   createTool(
-    "project-info",
+    "project_info",
     "Get detailed information about a specific project",
     {
       projectId: z.string().describe("ID of the project")
@@ -24,7 +24,7 @@ export const projectTools = [
   ),
 
   createTool(
-    "project-create",
+    "project_create",
     "Create a new project",
     {
       name: z.string().describe("Name of the project"),
@@ -36,7 +36,7 @@ export const projectTools = [
   ),
 
   createTool(
-    "project-delete",
+    "project_delete",
     "Delete a project",
     {
       projectId: z.string().describe("ID of the project to delete")
@@ -47,7 +47,7 @@ export const projectTools = [
   ),
 
   createTool(
-    "project-environments",
+    "project_environments",
     "List all environments in a project",
     {
       projectId: z.string().describe("ID of the project")

--- a/src/tools/project.tool.ts
+++ b/src/tools/project.tool.ts
@@ -1,11 +1,23 @@
+import { createTool, formatToolDescription } from '@/utils/tools.js';
 import { z } from 'zod';
-import { createTool } from '@/utils/tools.js';
 import { projectService } from '@/services/project.service.js';
 
 export const projectTools = [
   createTool(
     "project_list",
-    "List all projects",
+    formatToolDescription({
+      type: 'API',
+      description: "List all projects in your Railway account",
+      bestFor: [
+        "Getting an overview of all projects",
+        "Finding project IDs",
+        "Project discovery and management"
+      ],
+      relations: {
+        nextSteps: ["project_info", "service_list"],
+        related: ["project_create", "project_delete"]
+      }
+    }),
     {},
     async () => {
       return projectService.listProjects();
@@ -14,34 +26,82 @@ export const projectTools = [
 
   createTool(
     "project_info",
-    "Get detailed information about a specific project",
+    formatToolDescription({
+      type: 'API',
+      description: "Get detailed information about a specific Railway project",
+      bestFor: [
+        "Viewing project details and status",
+        "Checking environments and services",
+        "Project configuration review"
+      ],
+      relations: {
+        prerequisites: ["project_list"],
+        nextSteps: ["service_list", "variable_list"],
+        related: ["project_update", "project_delete"]
+      }
+    }),
     {
-      projectId: z.string().describe("ID of the project")
+      projectId: z.string().describe("ID of the project to get information about")
     },
-    async ({projectId}) => {
+    async ({ projectId }) => {
       return projectService.getProject(projectId);
     }
   ),
 
   createTool(
     "project_create",
-    "Create a new project",
+    formatToolDescription({
+      type: 'API',
+      description: "Create a new Railway project",
+      bestFor: [
+        "Starting new applications",
+        "Setting up development environments",
+        "Creating project spaces"
+      ],
+      notFor: [
+        "Duplicating existing projects",
+      ],
+      relations: {
+        nextSteps: [
+          "service_create_from_repo",
+          "service_create_from_image",
+          "database_deploy"
+        ],
+        related: ["project_delete", "project_update"]
+      }
+    }),
     {
-      name: z.string().describe("Name of the project"),
-      teamId: z.string().optional().describe("ID of the team to create the project in (optional)")
+      name: z.string().describe("Name for the new project"),
+      teamId: z.string().optional().describe("Optional team ID to create the project under")
     },
-    async ({name, teamId}) => {
+    async ({ name, teamId }) => {
       return projectService.createProject(name, teamId);
     }
   ),
 
   createTool(
     "project_delete",
-    "Delete a project",
+    formatToolDescription({
+      type: 'API',
+      description: "Delete a Railway project and all its resources",
+      bestFor: [
+        "Removing unused projects",
+        "Cleaning up test projects",
+      ],
+      notFor: [
+        "Temporary project deactivation",
+        "Service-level cleanup (use service_delete)"
+      ],
+      relations: {
+        prerequisites: ["project_list", "project_info"],
+        alternatives: ["service_delete"],
+        related: ["project_create"]
+      }
+    }),
     {
       projectId: z.string().describe("ID of the project to delete")
     },
-    async ({projectId}) => {
+    async ({ projectId }) => {
       return projectService.deleteProject(projectId);
     }
   ),

--- a/src/tools/service.tool.ts
+++ b/src/tools/service.tool.ts
@@ -4,7 +4,7 @@ import { serviceService } from '@/services/service.service.js';
 
 export const serviceTools = [
   createTool(
-    "service-list",
+    "service_list",
     "List all services in a specific project",
     {
       projectId: z.string().describe("ID of the project to list services for")
@@ -15,7 +15,7 @@ export const serviceTools = [
   ),
 
   createTool(
-    "service-info",
+    "service_info",
     "Get detailed information about a specific service",
     {
       projectId: z.string().describe("ID of the project"),
@@ -28,7 +28,7 @@ export const serviceTools = [
   ),
 
   createTool(
-    "service-create-from-repo",
+    "service_create_from_repo",
     "Create a new service in a project from a GitHub repository, format as 'owner/repo'",
     {
       projectId: z.string().describe("ID of the project to create the service in"),
@@ -41,7 +41,7 @@ export const serviceTools = [
   ),
 
   createTool(
-    "service-create-from-image",
+    "service_create_from_image",
     "Create a new service in a project from a Docker image",
     {
       projectId: z.string().describe("ID of the project to create the service in"),
@@ -56,7 +56,7 @@ export const serviceTools = [
   // TODO: Add validation for config
   // TODO: Test this
   createTool(
-    "service-update",
+    "service_update",
     "Update service configuration",
     {
       projectId: z.string().describe("ID of the project"),
@@ -77,7 +77,7 @@ export const serviceTools = [
   ),
 
   createTool(
-    "service-delete",
+    "service_delete",
     "Delete a service from a project",
     {
       projectId: z.string().describe("ID of the project"),
@@ -89,7 +89,7 @@ export const serviceTools = [
   ),
 
   createTool(
-    "service-restart",
+    "service_restart",
     "Restart a service in a specific environment",
     {
       serviceId: z.string().describe("ID of the service"),

--- a/src/tools/service.tool.ts
+++ b/src/tools/service.tool.ts
@@ -1,13 +1,27 @@
 import { z } from 'zod';
-import { createTool } from '@/utils/tools.js';
+import { createTool, formatToolDescription } from '@/utils/tools.js';
 import { serviceService } from '@/services/service.service.js';
+import { RegionCodeSchema } from '@/types.js';
 
 export const serviceTools = [
   createTool(
-    "service_list",
-    "List all services in a specific project",
+    "service_list", // TODO: update this tool to also return the status of the service
+    formatToolDescription({
+      type: 'API',
+      description: "List all services in a specific Railway project",
+      bestFor: [
+        "Getting an overview of a project's services",
+        "Finding service IDs",
+        "Checking service status",
+      ],
+      relations: {
+        prerequisites: ["project_list"],
+        nextSteps: ["service_info", "deployment_list"],
+        related: ["project_info", "variable_list"]
+      }
+    }),
     {
-      projectId: z.string().describe("ID of the project to list services for")
+      projectId: z.string().describe("ID of the project to list services from")
     },
     async ({ projectId }) => {
       return serviceService.listServices(projectId);
@@ -16,11 +30,24 @@ export const serviceTools = [
 
   createTool(
     "service_info",
-    "Get detailed information about a specific service",
+    formatToolDescription({
+      type: 'API',
+      description: "Get detailed information about a specific service",
+      bestFor: [
+        "Viewing service configuration and status",
+        "Checking deployment details",
+        "Monitoring service health"
+      ],
+      relations: {
+        prerequisites: ["service_list"],
+        nextSteps: ["deployment_list", "variable_list"],
+        related: ["service_update", "deployment_trigger"]
+      }
+    }),
     {
-      projectId: z.string().describe("ID of the project"),
-      serviceId: z.string().describe("ID of the service"),
-      environmentId: z.string().describe("ID of the environment")
+      projectId: z.string().describe("ID of the project containing the service"),
+      serviceId: z.string().describe("ID of the service to get information about"),
+      environmentId: z.string().describe("ID of the environment to check (usually obtained from service_list)")
     },
     async ({ projectId, serviceId, environmentId }) => {
       return serviceService.getServiceInfo(projectId, serviceId, environmentId);
@@ -29,11 +56,30 @@ export const serviceTools = [
 
   createTool(
     "service_create_from_repo",
-    "Create a new service in a project from a GitHub repository, format as 'owner/repo'",
+    formatToolDescription({
+      type: 'API',
+      description: "Create a new service from a GitHub repository",
+      bestFor: [
+        "Deploying applications from source code",
+        "Services that need build processes",
+        "GitHub-hosted projects"
+      ],
+      notFor: [
+        "Pre-built Docker images (use service_create_from_image)",
+        "Database deployments (use database_deploy)",
+        "Static file hosting"
+      ],
+      relations: {
+        prerequisites: ["project_list"],
+        nextSteps: ["variable_set", "service_update"],
+        alternatives: ["service_create_from_image", "database_deploy"],
+        related: ["deployment_trigger", "service_info"]
+      }
+    }),
     {
       projectId: z.string().describe("ID of the project to create the service in"),
-      repo: z.string().describe("GitHub repository URL, format as 'owner/repo'"),
-      name: z.string().optional().describe("Custom name for the service (optional)")
+      repo: z.string().describe("GitHub repository URL or name (e.g., 'owner/repo')"),
+      name: z.string().optional().describe("Optional custom name for the service")
     },
     async ({ projectId, repo, name }) => {
       return serviceService.createServiceFromRepo(projectId, repo, name);
@@ -42,11 +88,30 @@ export const serviceTools = [
 
   createTool(
     "service_create_from_image",
-    "Create a new service in a project from a Docker image",
+    formatToolDescription({
+      type: 'API',
+      description: "Create a new service from a Docker image",
+      bestFor: [
+        "Custom database deployments",
+        "Pre-built container deployments",
+        "Specific version requirements"
+      ],
+      notFor: [
+        "Standard database deployments (use database_deploy)",
+        "GitHub repository deployments (use service_create_from_repo)",
+        "Services needing build process"
+      ],
+      relations: {
+        prerequisites: ["project_list"],
+        nextSteps: ["variable_set", "service_update", "tcp_proxy_create"],
+        alternatives: ["database_deploy", "service_create_from_repo"],
+        related: ["volume_create", "deployment_trigger"]
+      }
+    }),
     {
       projectId: z.string().describe("ID of the project to create the service in"),
-      image: z.string().describe("Docker image name"),
-      name: z.string().optional().describe("Custom name for the service (optional)")
+      image: z.string().describe("Docker image to use (e.g., 'postgres:13-alpine')"),
+      name: z.string().optional().describe("Optional custom name for the service")
     },
     async ({ projectId, image, name }) => {
       return serviceService.createServiceFromImage(projectId, image, name);
@@ -57,31 +122,65 @@ export const serviceTools = [
   // TODO: Test this
   createTool(
     "service_update",
-    "Update service configuration",
+    formatToolDescription({
+      type: 'API',
+      description: "Update a service's configuration",
+      bestFor: [
+        "Changing service settings",
+        "Updating resource limits",
+        "Modifying deployment configuration"
+      ],
+      notFor: [
+        "Updating environment variables (use variable_set)",
+        "Restarting services (use service_restart)",
+        "Triggering new deployments (use deployment_trigger)"
+      ],
+      relations: {
+        prerequisites: ["service_list", "service_info"],
+        nextSteps: ["deployment_trigger"],
+        related: ["service_restart", "variable_set"]
+      }
+    }),
     {
-      projectId: z.string().describe("ID of the project"),
-      serviceId: z.string().describe("ID of the service"),
-      environmentId: z.string().describe("ID of the environment"),
-      config: z.object({
-        buildCommand: z.string().optional(),
-        startCommand: z.string().optional(),
-        rootDirectory: z.string().optional(),
-        healthcheckPath: z.string().optional(),
-        numReplicas: z.number().optional(),
-        sleepApplication: z.boolean().optional()
-      }).describe("Service configuration options")
+      projectId: z.string().describe("ID of the project containing the service"),
+      serviceId: z.string().describe("ID of the service to update"),
+      environmentId: z.string().describe("ID of the environment to update (usually obtained from service_info)"),
+      region: RegionCodeSchema.optional().describe("Optional: Region to deploy the service in"),
+      rootDirectory: z.string().optional().describe("Optional: Root directory containing the service code"),
+      buildCommand: z.string().optional().describe("Optional: Command to build the service"),
+      startCommand: z.string().optional().describe("Optional: Command to start the service"),
+      numReplicas: z.number().optional().describe("Optional: Number of service replicas to run"),
+      healthcheckPath: z.string().optional().describe("Optional: Path for health checks"),
+      sleepApplication: z.boolean().optional().describe("Optional: Whether to enable sleep mode")
     },
-    async ({ projectId, serviceId, environmentId, config }) => {
+    async ({ projectId, serviceId, environmentId, ...config }) => {
       return serviceService.updateService(projectId, serviceId, environmentId, config);
     }
   ),
 
   createTool(
     "service_delete",
-    "Delete a service from a project",
+    formatToolDescription({
+      type: 'API',
+      description: "Delete a service from a project",
+      bestFor: [
+        "Removing unused services",
+        "Cleaning up test services",
+        "Project reorganization"
+      ],
+      notFor: [
+        "Temporary service stoppage (use service_restart)",
+        "Updating service configuration (use service_update)"
+      ],
+      relations: {
+        prerequisites: ["service_list", "service_info"],
+        alternatives: ["service_restart"],
+        related: ["project_delete"]
+      }
+    }),
     {
-      projectId: z.string().describe("ID of the project"),
-      serviceId: z.string().describe("ID of the service"),
+      projectId: z.string().describe("ID of the project containing the service"),
+      serviceId: z.string().describe("ID of the service to delete")
     },
     async ({ projectId, serviceId }) => {
       return serviceService.deleteService(projectId, serviceId);
@@ -90,10 +189,28 @@ export const serviceTools = [
 
   createTool(
     "service_restart",
-    "Restart a service in a specific environment",
+    formatToolDescription({
+      type: 'API',
+      description: "Restart a service in a specific environment",
+      bestFor: [
+        "Applying configuration changes",
+        "Clearing service state",
+        "Resolving runtime issues"
+      ],
+      notFor: [
+        "Deploying new code (use deployment_trigger)",
+        "Updating service config (use service_update)",
+        "Long-term service stoppage (use service_delete)"
+      ],
+      relations: {
+        prerequisites: ["service_list"],
+        alternatives: ["deployment_trigger"],
+        related: ["service_info", "deployment_logs"]
+      }
+    }),
     {
-      serviceId: z.string().describe("ID of the service"),
-      environmentId: z.string().describe("ID of the environment")
+      serviceId: z.string().describe("ID of the service to restart"),
+      environmentId: z.string().describe("ID of the environment where the service should be restarted (usually obtained from service_info)")
     },
     async ({ serviceId, environmentId }) => {
       return serviceService.restartService(serviceId, environmentId);

--- a/src/tools/tcpProxy.tool.ts
+++ b/src/tools/tcpProxy.tool.ts
@@ -1,0 +1,47 @@
+import { z } from 'zod';
+import { createTool } from '@/utils/tools.js';
+import { tcpProxyService } from '@/services/tcpProxy.service.js';
+
+export const tcpProxyTools = [
+  createTool(
+    "tcp_proxy_list",
+    "List all TCP proxies for a service in a specific environment",
+    {
+      environmentId: z.string().describe("ID of the environment"),
+      serviceId: z.string().describe("ID of the service")
+    },
+    async ({ environmentId, serviceId }) => {
+      return tcpProxyService.listTcpProxies(environmentId, serviceId);
+    }
+  ),
+
+  createTool(
+    "tcp_proxy_create",
+    "Create a new TCP proxy for a service",
+    {
+      environmentId: z.string().describe("ID of the environment"),
+      serviceId: z.string().describe("ID of the service"),
+      applicationPort: z.number().describe("Port of application/service to proxy, usually based off of the service's Dockerfile or designated running port.")
+    },
+    async ({ environmentId, serviceId, applicationPort }) => {
+      const input = {
+        environmentId,
+        serviceId,
+        applicationPort
+      };
+
+      return tcpProxyService.createTcpProxy(input);
+    }
+  ),
+
+  createTool(
+    "tcp_proxy_delete",
+    "Delete a TCP proxy",
+    {
+      id: z.string().describe("ID of the TCP proxy to delete")
+    },
+    async ({ id }) => {
+      return tcpProxyService.deleteTcpProxy(id);
+    }
+  )
+]; 

--- a/src/tools/tcpProxy.tool.ts
+++ b/src/tools/tcpProxy.tool.ts
@@ -1,14 +1,27 @@
+import { createTool, formatToolDescription } from '@/utils/tools.js';
 import { z } from 'zod';
-import { createTool } from '@/utils/tools.js';
 import { tcpProxyService } from '@/services/tcpProxy.service.js';
 
 export const tcpProxyTools = [
   createTool(
     "tcp_proxy_list",
-    "List all TCP proxies for a service in a specific environment",
+    formatToolDescription({
+      type: 'API',
+      description: "List all TCP proxies for a service in a specific environment",
+      bestFor: [
+        "Viewing TCP proxy configurations",
+        "Managing external access",
+        "Auditing service endpoints"
+      ],
+      relations: {
+        prerequisites: ["service_list"],
+        nextSteps: ["tcp_proxy_create"],
+        related: ["domain_list", "service_info"]
+      }
+    }),
     {
-      environmentId: z.string().describe("ID of the environment"),
-      serviceId: z.string().describe("ID of the service")
+      environmentId: z.string().describe("ID of the environment containing the service"),
+      serviceId: z.string().describe("ID of the service to list TCP proxies for")
     },
     async ({ environmentId, serviceId }) => {
       return tcpProxyService.listTcpProxies(environmentId, serviceId);
@@ -17,31 +30,63 @@ export const tcpProxyTools = [
 
   createTool(
     "tcp_proxy_create",
-    "Create a new TCP proxy for a service",
+    formatToolDescription({
+      type: 'API',
+      description: "Create a new TCP proxy for a service",
+      bestFor: [
+        "Setting up database access",
+        "Configuring external connections",
+        "Exposing TCP services"
+      ],
+      notFor: [
+        "HTTP/HTTPS endpoints (use domain_create)",
+        "Internal service communication"
+      ],
+      relations: {
+        prerequisites: ["service_list"],
+        nextSteps: ["tcp_proxy_list"],
+        alternatives: ["domain_create"],
+        related: ["service_info", "service_update"]
+      }
+    }),
     {
-      environmentId: z.string().describe("ID of the environment"),
+      environmentId: z.string().describe("ID of the environment (usually obtained from service_info)"),
       serviceId: z.string().describe("ID of the service"),
       applicationPort: z.number().describe("Port of application/service to proxy, usually based off of the service's Dockerfile or designated running port.")
     },
     async ({ environmentId, serviceId, applicationPort }) => {
-      const input = {
+      return tcpProxyService.createTcpProxy({
         environmentId,
         serviceId,
         applicationPort
-      };
-
-      return tcpProxyService.createTcpProxy(input);
+      });
     }
   ),
 
   createTool(
     "tcp_proxy_delete",
-    "Delete a TCP proxy",
+    formatToolDescription({
+      type: 'API',
+      description: "Delete a TCP proxy",
+      bestFor: [
+        "Removing unused proxies",
+        "Security management",
+        "Endpoint cleanup"
+      ],
+      notFor: [
+        "Temporary proxy disabling",
+        "Port updates"
+      ],
+      relations: {
+        prerequisites: ["tcp_proxy_list"],
+        related: ["service_update"]
+      }
+    }),
     {
-      id: z.string().describe("ID of the TCP proxy to delete")
+      proxyId: z.string().describe("ID of the TCP proxy to delete")
     },
-    async ({ id }) => {
-      return tcpProxyService.deleteTcpProxy(id);
+    async ({ proxyId }) => {
+      return tcpProxyService.deleteTcpProxy(proxyId);
     }
   )
 ]; 

--- a/src/tools/variable.tool.ts
+++ b/src/tools/variable.tool.ts
@@ -1,15 +1,28 @@
+import { createTool, formatToolDescription } from '@/utils/tools.js';
 import { z } from 'zod';
-import { createTool } from '@/utils/tools.js';
 import { variableService } from '@/services/variable.service.js';
 
 export const variableTools = [
   createTool(
-    "variable_list",
-    "List variables for a service in a specific environment",
+    "list_service_variables",
+    formatToolDescription({
+      type: 'API',
+      description: "List all environment variables for a service",
+      bestFor: [
+        "Viewing service configuration",
+        "Auditing environment variables",
+        "Checking connection strings"
+      ],
+      relations: {
+        prerequisites: ["service_list"],
+        nextSteps: ["variable_set", "variable_delete"],
+        related: ["service_info", "variable_bulk_set"]
+      }
+    }),
     {
-      projectId: z.string().describe("ID of the project"),
-      environmentId: z.string().describe("ID of the environment"),
-      serviceId: z.string().optional().describe("ID of the service (optional, if omitted lists shared variables)")
+      projectId: z.string().describe("ID of the project containing the service"),
+      environmentId: z.string().describe("ID of the environment to list variables from (usually obtained from service_list)"),
+      serviceId: z.string().optional().describe("Optional: ID of the service to list variables for, if not provided, shared variables across all services will be listed")
     },
     async ({ projectId, environmentId, serviceId }) => {
       return variableService.listVariables(projectId, environmentId, serviceId);
@@ -18,13 +31,31 @@ export const variableTools = [
 
   createTool(
     "variable_set",
-    "Create or update a variable for a service in a specific environment",
+    formatToolDescription({
+      type: 'API',
+      description: "Create or update an environment variable",
+      bestFor: [
+        "Setting configuration values",
+        "Updating connection strings",
+        "Managing service secrets"
+      ],
+      notFor: [
+        "Bulk variable updates (use variable_bulk_set)",
+        "Temporary configuration changes"
+      ],
+      relations: {
+        prerequisites: ["service_list"],
+        nextSteps: ["deployment_trigger", "service_restart"],
+        alternatives: ["variable_bulk_set"],
+        related: ["variable_list", "variable_delete"]
+      }
+    }),
     {
-      projectId: z.string().describe("ID of the project"),
-      environmentId: z.string().describe("ID of the environment"),
-      name: z.string().describe("Name of the variable"),
-      value: z.string().describe("Value of the variable"),
-      serviceId: z.string().optional().describe("ID of the service (optional, if omitted creates/updates a shared variable)")
+      projectId: z.string().describe("ID of the project containing the service"),
+      environmentId: z.string().describe("ID of the environment for the variable (usually obtained from service_list)"),
+      name: z.string().describe("Name of the environment variable"),
+      value: z.string().describe("Value to set for the variable"),
+      serviceId: z.string().optional().describe("Optional: ID of the service for the variable, if omitted creates/updates a shared variable")
     },
     async ({ projectId, environmentId, name, value, serviceId }) => {
       return variableService.upsertVariable(projectId, environmentId, name, value, serviceId);
@@ -33,10 +64,27 @@ export const variableTools = [
 
   createTool(
     "variable_delete",
-    "Delete a variable for a service in a specific environment",
+    formatToolDescription({
+      type: 'API',
+      description: "Delete a variable for a service in a specific environment",
+      bestFor: [
+        "Removing unused configuration",
+        "Security cleanup",
+        "Configuration management"
+      ],
+      notFor: [
+        "Temporary variable disabling",
+        "Bulk variable removal"
+      ],
+      relations: {
+        prerequisites: ["service_list"],
+        nextSteps: ["deployment_trigger", "service_restart"],
+        related: ["variable_list", "variable_set"]
+      }
+    }),
     {
       projectId: z.string().describe("ID of the project"),
-      environmentId: z.string().describe("ID of the environment"),
+      environmentId: z.string().describe("ID of the environment to delete the variable from (usually obtained from service_list)"),
       name: z.string().describe("Name of the variable to delete"),
       serviceId: z.string().optional().describe("ID of the service (optional, if omitted deletes a shared variable)")
     },
@@ -48,12 +96,30 @@ export const variableTools = [
   // TODO: Test this better
   createTool(
     "variable_bulk_set",
-    "Bulk update variables for a service in a specific environment",
+    formatToolDescription({
+      type: 'WORKFLOW',
+      description: "Create or update multiple environment variables at once",
+      bestFor: [
+        "Migrating configuration between services",
+        "Initial service setup",
+        "Bulk configuration updates"
+      ],
+      notFor: [
+        "Single variable updates (use variable_set)",
+        "Temporary configuration changes"
+      ],
+      relations: {
+        prerequisites: ["service_list"],
+        nextSteps: ["deployment_trigger", "service_restart"],
+        alternatives: ["variable_set"],
+        related: ["variable_list", "service_update"]
+      }
+    }),
     {
-      projectId: z.string().describe("ID of the project"),
-      environmentId: z.string().describe("ID of the environment"),
+      projectId: z.string().describe("ID of the project containing the service"),
+      environmentId: z.string().describe("ID of the environment for the variables (usually obtained from service_list)"),
       variables: z.record(z.string()).describe("Object mapping variable names to values"),
-      serviceId: z.string().optional().describe("ID of the service (optional, if omitted updates shared variables)")
+      serviceId: z.string().optional().describe("Optional: ID of the service for the variables, if omitted updates shared variables)")
     },
     async ({ projectId, environmentId, variables, serviceId }) => {
       return variableService.bulkUpsertVariables(projectId, environmentId, variables, serviceId);
@@ -63,11 +129,29 @@ export const variableTools = [
   // TODO: Test this
   createTool(
     "variable_copy",
-    "Copy variables from one environment to another",
+    formatToolDescription({
+      type: 'WORKFLOW',
+      description: "Copy variables from one environment to another",
+      bestFor: [
+        "Environment migration",
+        "Configuration sharing",
+        "Environment duplication"
+      ],
+      notFor: [
+        "Single variable updates (use variable_set)",
+        "Temporary configuration changes"
+      ],
+      relations: {
+        prerequisites: ["service_list"],
+        nextSteps: ["deployment_trigger", "service_restart"],
+        alternatives: ["variable_set"],
+        related: ["variable_list", "service_update"]
+      }
+    }),
     {
       projectId: z.string().describe("ID of the project"),
-      sourceEnvironmentId: z.string().describe("ID of the source environment"),
-      targetEnvironmentId: z.string().describe("ID of the target environment"),
+      sourceEnvironmentId: z.string().describe("ID of the source environment (usually obtained from project_info)"),
+      targetEnvironmentId: z.string().describe("ID of the target environment (usually obtained from project_info)"),
       serviceId: z.string().optional().describe("ID of the service (optional, if omitted copies shared variables)"),
       overwrite: z.boolean().optional().default(false).describe("Whether to overwrite existing variables in the target environment")
     },

--- a/src/tools/variable.tool.ts
+++ b/src/tools/variable.tool.ts
@@ -4,7 +4,7 @@ import { variableService } from '@/services/variable.service.js';
 
 export const variableTools = [
   createTool(
-    "variable-list",
+    "variable_list",
     "List variables for a service in a specific environment",
     {
       projectId: z.string().describe("ID of the project"),
@@ -17,7 +17,7 @@ export const variableTools = [
   ),
 
   createTool(
-    "variable-set",
+    "variable_set",
     "Create or update a variable for a service in a specific environment",
     {
       projectId: z.string().describe("ID of the project"),
@@ -32,7 +32,7 @@ export const variableTools = [
   ),
 
   createTool(
-    "variable-delete",
+    "variable_delete",
     "Delete a variable for a service in a specific environment",
     {
       projectId: z.string().describe("ID of the project"),
@@ -47,7 +47,7 @@ export const variableTools = [
 
   // TODO: Test this better
   createTool(
-    "variable-bulk-set",
+    "variable_bulk_set",
     "Bulk update variables for a service in a specific environment",
     {
       projectId: z.string().describe("ID of the project"),
@@ -62,7 +62,7 @@ export const variableTools = [
 
   // TODO: Test this
   createTool(
-    "variable-copy",
+    "variable_copy",
     "Copy variables from one environment to another",
     {
       projectId: z.string().describe("ID of the project"),

--- a/src/tools/volume.tool.ts
+++ b/src/tools/volume.tool.ts
@@ -1,0 +1,53 @@
+import { z } from 'zod';
+import { createTool } from '@/utils/tools.js';
+import { volumeService } from '@/services/volume.service.js';
+
+export const volumeTools = [
+  createTool(
+    "volume_list",
+    "List all volumes in a project",
+    {
+      projectId: z.string().describe("ID of the project to list volumes for")
+    },
+    async ({ projectId }) => {
+      return volumeService.listVolumes(projectId);
+    }
+  ),
+
+  createTool(
+    "volume_create",
+    "Create a new volume in a project",
+    {
+      projectId: z.string().describe("ID of the project to create the volume in"),
+      serviceId: z.string().describe("ID of the service to attach the volume to"),
+      environmentId: z.string().describe("ID of the environment to create the volume in"),
+      mountPath: z.string().describe("Path to mount the volume on")
+    },
+    async ({ projectId, serviceId, environmentId, mountPath }) => {
+      return volumeService.createVolume(projectId, serviceId, environmentId, mountPath);
+    }
+  ),
+
+  createTool(
+    "volume_update",
+    "Update a volume's properties",
+    {
+      volumeId: z.string().describe("ID of the volume to update"),
+      name: z.string().describe("New name for the volume")
+    },
+    async ({ volumeId, name }) => {
+      return volumeService.updateVolume(volumeId, name);
+    }
+  ),
+
+  createTool(
+    "volume_delete",
+    "Delete a volume",
+    {
+      volumeId: z.string().describe("ID of the volume to delete")
+    },
+    async ({ volumeId }) => {
+      return volumeService.deleteVolume(volumeId);
+    }
+  )
+]; 

--- a/src/tools/volume.tool.ts
+++ b/src/tools/volume.tool.ts
@@ -1,11 +1,24 @@
+import { createTool, formatToolDescription } from '@/utils/tools.js';
 import { z } from 'zod';
-import { createTool } from '@/utils/tools.js';
 import { volumeService } from '@/services/volume.service.js';
 
 export const volumeTools = [
   createTool(
     "volume_list",
-    "List all volumes in a project",
+    formatToolDescription({
+      type: 'API',
+      description: "List all volumes in a project",
+      bestFor: [
+        "Viewing persistent storage configurations",
+        "Managing data volumes",
+        "Auditing storage usage"
+      ],
+      relations: {
+        prerequisites: ["project_list"],
+        nextSteps: ["volume_create"],
+        related: ["service_info", "database_deploy"]
+      }
+    }),
     {
       projectId: z.string().describe("ID of the project to list volumes for")
     },
@@ -16,14 +29,32 @@ export const volumeTools = [
 
   createTool(
     "volume_create",
-    "Create a new volume in a project",
+    formatToolDescription({
+      type: 'API',
+      description: "Create a new persistent volume for a service",
+      bestFor: [
+        "Setting up database storage",
+        "Configuring persistent data",
+        "Adding file storage"
+      ],
+      notFor: [
+        "Temporary storage needs",
+        "Static file hosting",
+        "Memory caching"
+      ],
+      relations: {
+        prerequisites: ["service_list"],
+        nextSteps: ["volume_list"],
+        related: ["service_update", "database_deploy"]
+      }
+    }),
     {
-      projectId: z.string().describe("ID of the project to create the volume in"),
-      serviceId: z.string().describe("ID of the service to attach the volume to"),
-      environmentId: z.string().describe("ID of the environment to create the volume in"),
-      mountPath: z.string().describe("Path to mount the volume on")
+      projectId: z.string().describe("ID of the project containing the service"),
+      environmentId: z.string().describe("ID of the environment for the volume (usually obtained from service_info)"),
+      serviceId: z.string().describe("ID of the service to attach volume to"),
+      mountPath: z.string().describe("Path where the volume should be mounted in the container")
     },
-    async ({ projectId, serviceId, environmentId, mountPath }) => {
+    async ({ projectId, environmentId, serviceId, mountPath }) => {
       return volumeService.createVolume(projectId, serviceId, environmentId, mountPath);
     }
   ),
@@ -42,7 +73,23 @@ export const volumeTools = [
 
   createTool(
     "volume_delete",
-    "Delete a volume",
+    formatToolDescription({
+      type: 'API',
+      description: "Delete a volume from a service",
+      bestFor: [
+        "Removing unused storage",
+        "Storage cleanup",
+        "Resource management"
+      ],
+      notFor: [
+        "Temporary data removal",
+        "Data backup (use volume_backup first)"
+      ],
+      relations: {
+        prerequisites: ["volume_list"],
+        related: ["service_update"]
+      }
+    }),
     {
       volumeId: z.string().describe("ID of the volume to delete")
     },

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,22 @@
-// General types
+import { z } from "zod";
+
+/**
+ * NOTE: ALL NON-METAL RAILWAY REGIONS -- TODO: Update when they've fully migrated to metal 🔄
+ */
+export const RegionCodeSchema = z.enum([
+  "asia-southeast1",
+  "asia-southeast1-eqsg3a", 
+  "europe-west4",
+  "europe-west4-drams3a",
+  "us-east4",
+  "us-east4-eqdc4a",
+  "us-west1",
+  "us-west2"
+]);
+
+// This creates the TypeScript type from the schema
+export type RegionCode = z.infer<typeof RegionCodeSchema>;
+
 export interface User {
   id: string;
   name: string | null;
@@ -69,28 +87,30 @@ export interface Service {
   featureFlags: string[];
 }
 
-export interface ServiceInstance {
-  id: string;
-  serviceId: string;
-  serviceName: string;
-  environmentId: string;
-  buildCommand?: string;
-  startCommand?: string;
-  rootDirectory?: string;
-  region?: string;
-  healthcheckPath?: string;
-  sleepApplication?: boolean;
-  numReplicas?: number;
-  builder?: string;
-  cronSchedule?: string;
-  healthcheckTimeout?: number;
-  isUpdatable?: boolean;
-  railwayConfigFile?: string;
-  restartPolicyType?: string;
-  restartPolicyMaxRetries?: number;
-  upstreamUrl?: string;
-  watchPatterns?: string[];
-}
+export const ServiceInstanceSchema = z.object({
+  id: z.string(),
+  serviceId: z.string(),
+  serviceName: z.string(),
+  environmentId: z.string(),
+  buildCommand: z.string().optional(),
+  startCommand: z.string().optional(),
+  rootDirectory: z.string().optional(),
+  region: RegionCodeSchema.optional(),
+  healthcheckPath: z.string().optional(),
+  sleepApplication: z.boolean().optional(),
+  numReplicas: z.number().optional(),
+  builder: z.string().optional(),
+  cronSchedule: z.string().optional(),
+  healthcheckTimeout: z.number().optional(),
+  isUpdatable: z.boolean().optional(),
+  railwayConfigFile: z.string().optional(),
+  restartPolicyType: z.string().optional(),
+  restartPolicyMaxRetries: z.number().optional(),
+  upstreamUrl: z.string().optional(),
+  watchPatterns: z.array(z.string()).optional()
+});
+
+export type ServiceInstance = z.infer<typeof ServiceInstanceSchema>;
 
 export interface Deployment {
   id: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,3 @@
-
 // General types
 export interface User {
   id: string;
@@ -118,6 +117,7 @@ export interface DeploymentLog {
     key: string;
     value: string;
   }[];
+  type: 'build' | 'deployment';
 }
 
 export interface Variable {
@@ -213,19 +213,31 @@ export interface DatabaseConfig {
   description: string;
   category: string;
   variables?: Record<string, string>;
+  port: number;
 }
 
 export const DATABASE_CONFIGS: Record<DatabaseType, DatabaseConfig> = {
   [DatabaseType.POSTGRES]: {
-    source: 'railwayapp-templates/postgres-ssl:15',
+    source: 'ghcr.io/railwayapp-templates/postgres-ssl:15',
     defaultName: 'PostgreSQL',
     description: 'PostgreSQL database service',
     category: 'SQL Databases',
+    port: 5432,
     variables: {
-      POSTGRES_URL: "jdbc:postgresql://${{POSTGRESUSER}}:${{POSTGRESPASSWORD}}@${{RAILWAY_TCP_PROXY_DOMAIN}}:${{RAILWAY_TCP_PROXY_PORT}}/${{POSTGRESDB}}",
-      POSTGRESUSER: "postgres-user",
-      POSTGRESPASSWORD: "postgres-password",
-      POSTGRESDB: "postgres-db"
+      // Variables for Railway
+      DATABASE_PUBLIC_URL: "postgresql://${{PGUSER}}:${{POSTGRES_PASSWORD}}@${{RAILWAY_TCP_PROXY_DOMAIN}}:${{RAILWAY_TCP_PROXY_PORT}}/${{PGDATABASE}}",
+      DATABASE_URL: "postgresql://${{PGUSER}}:${{POSTGRES_PASSWORD}}@${{RAILWAY_PRIVATE_DOMAIN}}:${{PGPORT}}/${{PGDATABASE}}",
+      PGDATA: "/var/lib/postgresql/data/pgdata", // for Volume Mounting in Railway
+      PGDATABASE: "${{POSTGRES_DB}}",
+      PGHOST: "${{RAILWAY_PRIVATE_DOMAIN}}",
+      PGPASSWORD: "${{POSTGRES_PASSWORD}}",
+      PGPORT: "5432",
+      PGUSER: "${{POSTGRES_USER}}",
+      
+      // Docker variables
+      POSTGRES_DB: "postgres-db",
+      POSTGRES_PASSWORD: "postgres-password",
+      POSTGRES_USER: "postgres-user",
     }
   },
   [DatabaseType.MYSQL]: {
@@ -233,63 +245,253 @@ export const DATABASE_CONFIGS: Record<DatabaseType, DatabaseConfig> = {
     defaultName: 'MySQL',
     description: 'MySQL database service',
     category: 'SQL Databases',
+    port: 3306,
     variables: {
-      MYSQL_PUBLIC_URL: "mysql://${{MYSQLUSER}}:${{MYSQL_ROOT_PASSWORD}}@${{RAILWAY_TCP_PROXY_DOMAIN}}:${{RAILWAY_TCP_PROXY_PORT}}/${{MYSQL_DATABASE}}",
-      MYSQL_URL: "mysql://${{MYSQLUSER}}:${{MYSQL_ROOT_PASSWORD}}@${{RAILWAY_PRIVATE_DOMAIN}}:3306/${{MYSQL_DATABASE}}",
+      // Railway variables
       MYSQLHOST: "${{RAILWAY_PRIVATE_DOMAIN}}",
-      MYSQLPORT: "3306",
-      MYSQLUSER: "root",
-      MYSQLPASSWORD: "mysql-password",
-      MYSQLDATABASE: "mysql-db",
+      MYSQLPASSWORD: "${{MYSQL_ROOT_PASSWORD}}",
+      MYSQLDATABASE: "${{MYSQL_DATABASE}}",
+
+      // Docker variables
+      MYSQL_DATABASE: "mysql-db",
+      MYSQL_PUBLIC_URL: "mysql://${{MYSQLUSER}}:${{MYSQL_ROOT_PASSWORD}}@${{RAILWAY_TCP_PROXY_DOMAIN}}:${{RAILWAY_TCP_PROXY_PORT}}/${{MYSQL_DATABASE}}",
+      MYSQL_URL: "mysql://${{MYSQLUSER}}:${{MYSQL_ROOT_PASSWORD}}@${{RAILWAY_PRIVATE_DOMAIN}}:${{MYSQLPORT}}/${{MYSQL_DATABASE}}",
       MYSQL_ROOT_PASSWORD: "mysql-password",
-    }
+      MYSQLUSER: "root",
+      MYSQLPORT: "3306",
+    },
   },
   [DatabaseType.MONGODB]: {
-    source: 'mongo:6',
+    source: 'mongo:7',
     defaultName: 'MongoDB',
     description: 'MongoDB NoSQL database service',
     category: 'NoSQL Databases',
+    port: 27017,
+    variables: {
+      // Docker
+      MONGO_INITDB_ROOT_PASSWORD: "mongo-password",
+      MONGO_INITDB_ROOT_USERNAME: "mongo-user",
+      MONGO_PUBLIC_URL: "mongodb://${{MONGO_INITDB_ROOT_USERNAME}}:${{MONGO_INITDB_ROOT_PASSWORD}}@${{RAILWAY_TCP_PROXY_DOMAIN}}:${{RAILWAY_TCP_PROXY_PORT}}",
+      MONGO_URL: "mongodb://${{MONGO_INITDB_ROOT_USERNAME}}:${{MONGO_INITDB_ROOT_PASSWORD}}@${{RAILWAY_PRIVATE_DOMAIN}}:${{MONGO_PORT}}",
+
+      // Railway
+      MONGOHOST: "${{RAILWAY_PRIVATE_DOMAIN}}",
+      MONGOPASSWORD: "${{MONGO_INITDB_ROOT_PASSWORD}}",
+      MONGOPORT: "27017",
+      MONGOUSER: "${{MONGO_INITDB_ROOT_USERNAME}}",
+    },
   },
   [DatabaseType.REDIS]: {
-    source: 'redis:7',
+    source: 'bitnami/redis:7.2.5',
     defaultName: 'Redis',
     description: 'Redis in-memory data store',
     category: 'In-Memory Stores',
+    port: 6379,
+    variables: {
+      // Docker
+      REDIS_PASSWORD: "redis-password",
+      REDIS_PORT: "6379",
+      REDISUSER: "default",
+      REDIS_RDB_POLICY: "3600#1 300#100 60#10000",
+      REDISPORT: "6379",
+      REDIS_AOF_ENABLED: "no",
+      
+      // Railway
+      REDISPASSWORD: "${{REDIS_PASSWORD}}",
+      REDISHOST: "${{RAILWAY_PRIVATE_DOMAIN}}",
+      RAILWAY_RUN_UID: "0",
+      REDIS_PUBLIC_URL: "redis://${{REDISUSER}}:${{REDIS_PASSWORD}}@${{RAILWAY_TCP_PROXY_DOMAIN}}:${{RAILWAY_TCP_PROXY_PORT}}",
+      REDIS_URL: "redis://${{REDISUSER}}:${{REDIS_PASSWORD}}@${{RAILWAY_PRIVATE_DOMAIN}}:${{REDISPORT}}",
+      RAILWAY_RUN_AS_ROOT: "true",
+    },
   },
   [DatabaseType.MINIO]: {
     source: 'minio:latest',
     defaultName: 'MinIO',
     description: 'MinIO object storage service',
     category: 'Object Storage',
+    port: 9000,
   },
   [DatabaseType.SQLITE3]: {
     source: 'sqlite:latest',
     defaultName: 'SQLite',
     description: 'SQLite relational database',
     category: 'SQL Databases',
+    port: 5432,
   },
   [DatabaseType.POCKETBASE]: {
     source: 'pocketbase/pocketbase:latest',
     defaultName: 'PocketBase',
     description: 'PocketBase lightweight, open-source, self-hosted backend',
     category: 'SQL Databases',
+    port: 8080,
   },
   [DatabaseType.CLICKHOUSE]: {
     source: 'clickhouse/clickhouse-server:23',
     defaultName: 'ClickHouse',
     description: 'ClickHouse column-oriented database',
     category: 'Analytics Databases',
+    port: 8123,
   },
   [DatabaseType.MARIADB]: {
     source: 'mariadb:10',
     defaultName: 'MariaDB',
     description: 'MariaDB relational database',
     category: 'SQL Databases',
+    port: 3306,
   },
   [DatabaseType.PGVECTOR]: {
     source: 'postgres:14',
     defaultName: 'PGVector',
     description: 'PGVector vector database',
     category: 'Vector Databases',
+    port: 5432,
   },
 };
+
+/**
+ * Input type for creating a service domain
+ */
+export interface ServiceDomainCreateInput {
+  /** ID of the environment */
+  environmentId: string;
+  /** ID of the service */
+  serviceId: string;
+  /** Custom domain name (optional) */
+  domain?: string;
+  /** Suffix for the domain (optional) */
+  suffix?: string;
+  /** Target port for the domain (optional) */
+  targetPort?: number;
+}
+
+/**
+ * Input type for updating a service domain
+ */
+export interface ServiceDomainUpdateInput {
+  /** ID of the domain to update */
+  id: string;
+  /** New target port for the domain */
+  targetPort: number;
+}
+
+/**
+ * Service domain model
+ */
+export interface ServiceDomain {
+  /** Unique identifier */
+  id: string;
+  /** Creation timestamp */
+  createdAt: string;
+  /** Deletion timestamp, null if not deleted */
+  deletedAt: string | null;
+  /** Full domain name */
+  domain: string;
+  /** ID of the environment */
+  environmentId: string;
+  /** ID of the project */
+  projectId: string;
+  /** ID of the service */
+  serviceId: string;
+  /** Suffix part of the domain (for service domains) */
+  suffix: string | null;
+  /** Target port the domain maps to */
+  targetPort: number | null;
+  /** Last update timestamp */
+  updatedAt: string;
+}
+
+/**
+ * Domain availability check result
+ */
+export interface DomainAvailabilityResult {
+  /** Whether the domain is available */
+  available: boolean;
+  /** Message explaining availability status */
+  message: string;
+}
+
+/**
+ * Result of listing domains for a service
+ */
+export interface DomainsListResult {
+  /** List of custom domains */
+  customDomains: ServiceDomain[];
+  /** List of service domains */
+  serviceDomains: ServiceDomain[];
+}
+
+/**
+ * TCP Proxy model
+ */
+export interface TcpProxy {
+  /** Unique identifier */
+  id: string;
+  /** Creation timestamp */
+  createdAt: string;
+  /** Deletion timestamp, null if not deleted */
+  deletedAt: string | null;
+  /** Domain for the TCP proxy */
+  domain: string;
+  /** ID of the environment */
+  environmentId: string;
+  /** ID of the service */
+  serviceId: string;
+  /** Container port that will be proxied */
+  applicationPort: number;
+  /** Proxy port that gets exposed */
+  proxyPort: number;
+  /** Last update timestamp */
+  updatedAt: string;
+}
+
+/**
+ * Input type for creating a TCP proxy
+ */
+export interface TcpProxyCreateInput {
+  /** ID of the environment */
+  environmentId: string;
+  /** ID of the service */
+  serviceId: string;
+  /** Container port that will be proxied */
+  applicationPort: number;
+}
+
+export interface Volume {
+  __typename?: string;
+  createdAt: string;
+  id: string;
+  name: string;
+  project: Project;
+  projectId: string;
+  volumeInstances: Connection<VolumeInstance[]>;
+}
+
+export interface VolumeCreateInput {
+  projectId: string; // Project to create volume in
+  serviceId: string; // Service to attach volume to
+  environmentId: string; // Environment to create volume in
+  mountPath: string; // Path to mount volume on
+}
+
+export interface VolumeUpdateInput {
+  name: string;
+}
+
+export interface VolumeInstance {
+  __typename?: string;
+  createdAt: string;
+  currentSizeMB?: number;
+  environmentId: string;
+  externalId?: string;
+  id: string;
+  mountPath?: string;
+  region?: string;
+  service: Service;
+  serviceId?: string;
+  sizeMB?: number;
+  state?: string;
+  type?: string;
+  volume: Volume;
+  volumeId: string;
+}

--- a/src/utils/tools.ts
+++ b/src/utils/tools.ts
@@ -1,6 +1,8 @@
 import { z } from 'zod';
 import { ToolCallback } from '@modelcontextprotocol/sdk/server/mcp.js';
 
+export type ToolType = 'API' | 'WORKFLOW' | 'COMPOSITE' | 'QUERY' | 'UTILITY';
+
 export type Tool<T extends z.ZodRawShape = z.ZodRawShape> = [
   string,
   string,
@@ -21,3 +23,59 @@ export function createTool<T extends z.ZodRawShape>(
     handler
   ] as const;
 } 
+export interface ToolRelations {
+  prerequisites?: string[];
+  alternatives?: string[];
+  nextSteps?: string[];
+  related?: string[];
+}
+
+export const formatToolDescription = ({
+  type,
+  description,
+  bestFor = [],
+  notFor = [],
+  relations = {},
+}: {
+  type: ToolType;
+  description: string;
+  bestFor?: string[];
+  notFor?: string[];
+  relations?: ToolRelations;
+}) => {
+  const sections = [
+    `[${type}] ${description}`,
+    
+    // Best For section
+    bestFor.length > 0 && [
+      '⚡️ Best for:',
+      ...bestFor.map(b => `  ✓ ${b}`)
+    ].join('\n'),
+    
+    // Not For section
+    notFor.length > 0 && [
+      '⚠️ Not for:',
+      ...notFor.map(n => `  × ${n}`)
+    ].join('\n'),
+    '\n\n\n',
+    
+    // Prerequisites section
+    relations?.prerequisites?.length! > 0 &&
+      `→ Prerequisites: ${relations?.prerequisites?.join(', ')}`,
+    
+    // Alternatives section
+    relations?.alternatives?.length! > 0 &&
+      `→ Alternatives: ${relations?.alternatives?.join(', ')}`,
+    
+    // Next Steps section
+    relations?.nextSteps?.length! > 0 &&
+      `→ Next steps: ${relations?.nextSteps?.join(', ')}`,
+    
+    // Related section
+    relations?.related?.length! > 0 &&
+      `→ Related: ${relations?.related?.join(', ')}`
+  ];
+
+  // Filter out falsy values and join with newlines
+  return sections.filter(Boolean).join('\n\n');
+};


### PR DESCRIPTION
## Notes
- adds tcpProxy CRUD
- add volume CRUD
- add domain CRUD
- add database CRUD (with template support for postgres, mysql, mongodb - more to come!)
- standardize description format
- fix queries and other flows
- add support for usage with Cursor and command-line environments (since Cursor doesn't work as nicely as Claude with its mcp.json)

## Notes for Future
- we need to update the Volume attaching to services eventually as Railway has announced their move to Metal. At the moment, Railway does **NOT** support Volumes attaching to services on Metal. Thus, in the database deploy workflow we're explicitly checking if the service is on metal and changing it to Cloud temporarily. [change here](https://github.com/jason-tan-swe/railway-mcp/pull/7/files#diff-c28a54a7e856bd8dc3bc881a82b70d6405a7dff5ede2f49da84f16aeea34131fR93-R97)
