### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@
   </table>
 </p>
 
+<a href="https://glama.ai/mcp/servers/lwn74iwigz">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/lwn74iwigz/badge" alt="railway-mcp MCP server" />
+</a>
 
 A [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server for integrating with the [Railway.app](https://railway.app) platform.
 
@@ -283,4 +286,3 @@ We welcome contributions from the community! Please see our [Contributing Guidel
 4. Delete any obsolete variables
 
 </details>
-


### PR DESCRIPTION
This PR adds a badge for the [railway-mcp](https://glama.ai/mcp/servers/lwn74iwigz) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/lwn74iwigz">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/lwn74iwigz/badge" alt="railway-mcp MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.